### PR TITLE
gh-2 [feat]: Add shared backend version package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 # @File    : .gitignore
 # @Author  : Frost Leo <frostleo.dev@gmail.com>
 # @Created : 2026-04-18
-# @Modified: 2026-04-18
+# @Modified: 2026-04-24
 #
 # Combined from github/gitignore Go.gitignore and Node.gitignore.
 # Sources:
@@ -47,8 +47,7 @@ profile.cov
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-# Go workspace file
-go.work
+# Go workspace checksum file
 go.work.sum
 
 # env file

--- a/go.work
+++ b/go.work
@@ -1,0 +1,5 @@
+go 1.25.6
+
+use (
+	./packages/shared
+)

--- a/packages/shared/go.mod
+++ b/packages/shared/go.mod
@@ -1,0 +1,3 @@
+module github.com/opendox/dox/packages/shared
+
+go 1.25.6

--- a/packages/shared/version/README.md
+++ b/packages/shared/version/README.md
@@ -1,0 +1,57 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : packages/shared/version/README.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-24
+  @Modified: 2026-04-24
+-->
+
+# Shared Version Package
+
+`packages/shared/version` provides build and source metadata for Dox backend binaries.
+
+The package is intentionally dependency-free. Build systems should inject metadata through Go `-ldflags -X`, while local development builds keep stable fallback values.
+
+## Build Metadata
+
+Supported build variables:
+
+```text
+github.com/opendox/dox/packages/shared/version.buildName
+github.com/opendox/dox/packages/shared/version.buildVersion
+github.com/opendox/dox/packages/shared/version.buildTime
+github.com/opendox/dox/packages/shared/version.buildUser
+github.com/opendox/dox/packages/shared/version.buildCGOEnabled
+github.com/opendox/dox/packages/shared/version.buildGitCommit
+github.com/opendox/dox/packages/shared/version.buildGitBranch
+github.com/opendox/dox/packages/shared/version.buildGitTag
+github.com/opendox/dox/packages/shared/version.buildGitDirty
+```
+
+Example:
+
+```bash
+go build -ldflags "\
+  -X github.com/opendox/dox/packages/shared/version.buildName=dox-server \
+  -X github.com/opendox/dox/packages/shared/version.buildVersion=0.1.0 \
+  -X github.com/opendox/dox/packages/shared/version.buildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+  -X github.com/opendox/dox/packages/shared/version.buildGitCommit=$(git rev-parse --short HEAD) \
+  -X github.com/opendox/dox/packages/shared/version.buildGitBranch=$(git rev-parse --abbrev-ref HEAD) \
+  -X github.com/opendox/dox/packages/shared/version.buildGitDirty=$(test -z "$(git status --porcelain)" && echo false || echo true)" \
+  ./server/cmd/dox-server
+```

--- a/packages/shared/version/doc.go
+++ b/packages/shared/version/doc.go
@@ -1,0 +1,25 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : doc.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+// Package version exposes build metadata shared by Dox backend binaries.
+package version

--- a/packages/shared/version/info.go
+++ b/packages/shared/version/info.go
@@ -1,0 +1,194 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : info.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"strings"
+)
+
+const unknownValue = "unknown"
+
+var (
+	buildName       = "dox"
+	buildVersion    = "0.1.0"
+	buildTime       = unknownValue
+	buildUser       = unknownValue
+	buildCGOEnabled = unknownValue
+	buildGitCommit  = unknownValue
+	buildGitBranch  = unknownValue
+	buildGitTag     = unknownValue
+	buildGitDirty   = unknownValue
+)
+
+// Info describes the build and source metadata of a Dox backend binary.
+type Info struct {
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+	BuildTime  string `json:"build_time"`
+	BuildUser  string `json:"build_user"`
+	GoVersion  string `json:"go_version"`
+	GOOS       string `json:"goos"`
+	GOARCH     string `json:"goarch"`
+	CGOEnabled string `json:"cgo_enabled"`
+	GitCommit  string `json:"git_commit"`
+	GitBranch  string `json:"git_branch"`
+	GitTag     string `json:"git_tag"`
+	GitDirty   string `json:"git_dirty"`
+}
+
+// GetInfo returns normalized version metadata for the current binary.
+func GetInfo() Info {
+	info := Info{
+		Name:       stableValue(buildName, "dox"),
+		Version:    stableValue(buildVersion, "0.1.0"),
+		BuildTime:  stableValue(buildTime, unknownValue),
+		BuildUser:  stableValue(buildUser, unknownValue),
+		GoVersion:  runtime.Version(),
+		GOOS:       runtime.GOOS,
+		GOARCH:     runtime.GOARCH,
+		CGOEnabled: stableValue(buildCGOEnabled, unknownValue),
+		GitCommit:  stableValue(buildGitCommit, unknownValue),
+		GitBranch:  stableValue(buildGitBranch, unknownValue),
+		GitTag:     stableValue(buildGitTag, unknownValue),
+		GitDirty:   stableValue(buildGitDirty, unknownValue),
+	}
+	applyBuildInfoFallback(&info)
+	return info
+}
+
+// String returns a stable multi-line representation for CLI output.
+func (i Info) String() string {
+	return fmt.Sprintf(`%s %s
+  Build Time  : %s
+  Build User  : %s
+  Go Version  : %s
+  GOOS        : %s
+  GOARCH      : %s
+  CGO Enabled : %s
+  Git Commit  : %s
+  Git Branch  : %s
+  Git Tag     : %s
+  Git Dirty   : %s
+`, i.Name, i.Version,
+		i.BuildTime,
+		i.BuildUser,
+		i.GoVersion,
+		i.GOOS,
+		i.GOARCH,
+		i.CGOEnabled,
+		i.GitCommit,
+		i.GitBranch,
+		i.GitTag,
+		i.GitDirty,
+	)
+}
+
+// Short returns a one-line representation for concise logs and diagnostics.
+func (i Info) Short() string {
+	commit := i.GitCommit
+	if !hasValue(commit) {
+		commit = unknownValue
+	}
+	if len(commit) > 12 {
+		commit = commit[:12]
+	}
+
+	state := "clean"
+	if i.IsDirty() {
+		state = "dirty"
+	}
+	if !hasValue(i.GitDirty) {
+		state = unknownValue
+	}
+
+	return fmt.Sprintf("%s %s (%s, %s)", i.Name, i.Version, commit, state)
+}
+
+// Fields returns version metadata as string fields for structured logging.
+func (i Info) Fields() map[string]string {
+	return map[string]string{
+		"name":        i.Name,
+		"version":     i.Version,
+		"build_time":  i.BuildTime,
+		"build_user":  i.BuildUser,
+		"go_version":  i.GoVersion,
+		"goos":        i.GOOS,
+		"goarch":      i.GOARCH,
+		"cgo_enabled": i.CGOEnabled,
+		"git_commit":  i.GitCommit,
+		"git_branch":  i.GitBranch,
+		"git_tag":     i.GitTag,
+		"git_dirty":   i.GitDirty,
+	}
+}
+
+// IsDirty reports whether the build was produced from a modified working tree.
+func (i Info) IsDirty() bool {
+	switch strings.ToLower(strings.TrimSpace(i.GitDirty)) {
+	case "1", "true", "yes", "y", "dirty", "modified":
+		return true
+	default:
+		return false
+	}
+}
+
+func applyBuildInfoFallback(info *Info) {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	if !hasValue(info.Version) && hasValue(buildInfo.Main.Version) && buildInfo.Main.Version != "(devel)" {
+		info.Version = buildInfo.Main.Version
+	}
+
+	settings := map[string]string{}
+	for _, setting := range buildInfo.Settings {
+		settings[setting.Key] = setting.Value
+	}
+	if !hasValue(info.GitCommit) {
+		info.GitCommit = stableValue(settings["vcs.revision"], info.GitCommit)
+	}
+	if !hasValue(info.BuildTime) {
+		info.BuildTime = stableValue(settings["vcs.time"], info.BuildTime)
+	}
+	if !hasValue(info.GitDirty) {
+		info.GitDirty = stableValue(settings["vcs.modified"], info.GitDirty)
+	}
+}
+
+func stableValue(value string, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func hasValue(value string) bool {
+	value = strings.TrimSpace(value)
+	return value != "" && !strings.EqualFold(value, unknownValue)
+}

--- a/packages/shared/version/info_test.go
+++ b/packages/shared/version/info_test.go
@@ -1,0 +1,113 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : info_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package version
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestGetInfoReturnsStableDefaults(t *testing.T) {
+	info := GetInfo()
+
+	if info.Name != "dox" {
+		t.Fatalf("expected default name dox, got %q", info.Name)
+	}
+	if info.Version != "0.1.0" {
+		t.Fatalf("expected default version 0.1.0, got %q", info.Version)
+	}
+	if info.GoVersion != runtime.Version() {
+		t.Fatalf("expected Go version %q, got %q", runtime.Version(), info.GoVersion)
+	}
+	if info.GOOS != runtime.GOOS {
+		t.Fatalf("expected GOOS %q, got %q", runtime.GOOS, info.GOOS)
+	}
+	if info.GOARCH != runtime.GOARCH {
+		t.Fatalf("expected GOARCH %q, got %q", runtime.GOARCH, info.GOARCH)
+	}
+	if info.Fields()["name"] != "dox" {
+		t.Fatal("expected fields to include name")
+	}
+}
+
+func TestStringIncludesStructuredBuildMetadata(t *testing.T) {
+	info := Info{
+		Name:       "dox-server",
+		Version:    "1.2.3",
+		BuildTime:  "2026-04-24T00:00:00Z",
+		BuildUser:  "builder",
+		GoVersion:  "go1.25.6",
+		GOOS:       "linux",
+		GOARCH:     "amd64",
+		CGOEnabled: "false",
+		GitCommit:  "abcdef1234567890",
+		GitBranch:  "main",
+		GitTag:     "v1.2.3",
+		GitDirty:   "false",
+	}
+
+	output := info.String()
+	for _, expected := range []string{
+		"dox-server 1.2.3",
+		"Build Time  : 2026-04-24T00:00:00Z",
+		"GOOS        : linux",
+		"Git Commit  : abcdef1234567890",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected output to contain %q, got:\n%s", expected, output)
+		}
+	}
+}
+
+func TestShortOutputTruncatesCommitAndReportsState(t *testing.T) {
+	info := Info{
+		Name:      "dox-scheduler",
+		Version:   "0.1.0",
+		GitCommit: "abcdef1234567890",
+		GitDirty:  "true",
+	}
+
+	got := info.Short()
+	want := "dox-scheduler 0.1.0 (abcdef123456, dirty)"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestIsDirtyNormalizesCommonValues(t *testing.T) {
+	dirtyValues := []string{"1", "true", "yes", "dirty", "modified"}
+	for _, value := range dirtyValues {
+		if !((Info{GitDirty: value}).IsDirty()) {
+			t.Fatalf("expected %q to be dirty", value)
+		}
+	}
+
+	cleanValues := []string{"", "unknown", "UNKNOWN", "0", "false", "clean"}
+	for _, value := range cleanValues {
+		if (Info{GitDirty: value}).IsDirty() {
+			t.Fatalf("expected %q to be clean", value)
+		}
+	}
+}


### PR DESCRIPTION
## Description

Adds the first shared backend package for Dox build metadata. The package lives in the new `packages/shared` Go module and is included by the root workspace for the planned multi-module backend layout.

## Related Links

- Closes #2

## Scope

- [ ] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [x] CI / tooling
- [ ] Security

## Implementation Notes

- Adds `packages/shared/version` as a dependency-free version metadata package for backend binaries.
- Tracks the root `go.work` file for the repository multi-module workspace and keeps `go.work.sum` ignored.
- Documents supported build metadata injection keys for future backend binaries.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Checks:

- [x] `git diff --cached --check`
- [x] `gofmt -w version/doc.go version/info.go version/info_test.go`
- [x] `GOCACHE=/home/frost/workspace/.cache/go-build go test ./...`
- [x] Signed commit verified with `git log --show-signature -1`

## Risks

The change is limited to a new shared package, workspace metadata, and build metadata documentation; it does not affect runtime services, database schema, credentials, or queue behavior.