### PR TITLE
gh-4 [feat]: Bootstrap server CLI entrypoint

### DIFF
--- a/go.work
+++ b/go.work
@@ -2,4 +2,5 @@ go 1.25.6
 
 use (
 	./packages/shared
+	./server
 )

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,48 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : server/README.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-24
+  @Modified: 2026-04-24
+-->
+
+# Dox Server
+
+`server` is the Web backend runtime for Dox.
+
+The current module only contains the CLI entrypoint and shared version command. HTTP server startup, configuration, logging, database access, and EDA integration are intentionally out of scope for this milestone.
+
+## Usage
+
+From the repository root:
+
+```bash
+go run ./server version
+```
+
+From the `server` module:
+
+```bash
+go run . version
+```
+
+Build the server CLI binary from the repository root:
+
+```bash
+go build -o dox-server ./server
+```

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,0 +1,15 @@
+module github.com/opendox/dox/server
+
+go 1.25.6
+
+require (
+	github.com/opendox/dox/packages/shared v0.0.0
+	github.com/spf13/cobra v1.10.2
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)
+
+replace github.com/opendox/dox/packages/shared => ../packages/shared

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/server/internal/command/root.go
+++ b/server/internal/command/root.go
@@ -1,0 +1,69 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : root.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package command
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// Config defines external command streams for the server CLI.
+type Config struct {
+	Out    io.Writer
+	ErrOut io.Writer
+}
+
+// Execute runs the server CLI with explicit args and stream configuration.
+func Execute(ctx context.Context, args []string, cfg Config) error {
+	cmd := NewRootCommand(cfg)
+	cmd.SetArgs(args)
+	return cmd.ExecuteContext(ctx)
+}
+
+// NewRootCommand builds the root command for the Dox Web backend runtime.
+func NewRootCommand(cfg Config) *cobra.Command {
+	out := cfg.Out
+	if out == nil {
+		out = os.Stdout
+	}
+	errOut := cfg.ErrOut
+	if errOut == nil {
+		errOut = os.Stderr
+	}
+
+	cmd := &cobra.Command{
+		Use:           "dox-server",
+		Short:         "Dox Web backend server",
+		Long:          "dox-server is the CLI entrypoint for the Dox Web backend runtime.",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+	cmd.AddCommand(newVersionCommand())
+	return cmd
+}

--- a/server/internal/command/root_test.go
+++ b/server/internal/command/root_test.go
@@ -1,0 +1,62 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : root_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package command
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRootCommandMetadata(t *testing.T) {
+	cmd := NewRootCommand(Config{})
+
+	if cmd.Use != "dox-server" {
+		t.Fatalf("expected root command use dox-server, got %q", cmd.Use)
+	}
+	if cmd.Short == "" {
+		t.Fatal("expected root command short description")
+	}
+}
+
+func TestVersionCommandPrintsSharedVersionInfo(t *testing.T) {
+	var out bytes.Buffer
+
+	err := Execute(context.Background(), []string{"version"}, Config{Out: &out})
+	if err != nil {
+		t.Fatalf("expected version command to succeed: %v", err)
+	}
+
+	output := out.String()
+	for _, expected := range []string{
+		"dox 0.1.0",
+		"Go Version",
+		"Git Commit",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected version output to contain %q, got:\n%s", expected, output)
+		}
+	}
+}

--- a/server/internal/command/version.go
+++ b/server/internal/command/version.go
@@ -1,0 +1,42 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : version.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package command
+
+import (
+	"fmt"
+
+	"github.com/opendox/dox/packages/shared/version"
+	"github.com/spf13/cobra"
+)
+
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print server version information",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, err := fmt.Fprint(cmd.OutOrStdout(), version.GetInfo().String())
+			return err
+		},
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -1,0 +1,39 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : main.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/opendox/dox/server/internal/command"
+)
+
+func main() {
+	if err := command.Execute(context.Background(), os.Args[1:], command.Config{}); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Description

Adds the initial `server` Go module for the Dox Web backend runtime. This PR only establishes the CLI entrypoint and version command; it does not start an HTTP server or introduce runtime infrastructure.

## Related Links

- Closes #4

## Scope

- [x] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [x] CI / tooling
- [ ] Security

## Implementation Notes

- Adds `server/main.go` as the thin process entrypoint for the Web backend runtime.
- Adds `server/internal/command` for Cobra command wiring.
- Adds `version` command backed by `packages/shared/version`.
- Adds `server` to the root Go workspace.
- Uses a local replace for `packages/shared` so the server module can tidy and test independently inside the monorepo.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Checks:

- [x] `gofmt -w main.go internal/command/root.go internal/command/version.go internal/command/root_test.go`
- [x] `GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath go test ./...` from `server`
- [x] `GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath go test ./packages/shared/... ./server/...` from repo root
- [x] `GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath go build -o /tmp/dox-server ./server`
- [x] `GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath go run ./server version`
- [x] Signed commit verified with `git log --show-signature -1`

## Risks

This PR intentionally does not include HTTP startup, Fiber integration, config, logger, database, queue, IAM, or API routes. Those should remain separate issues so the server runtime grows through small, reviewable steps.