### PR TITLE
gh-6 [feat]: Add shared config loader contract

### DIFF
--- a/packages/shared/config/README.md
+++ b/packages/shared/config/README.md
@@ -1,0 +1,46 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : packages/shared/config/README.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-24
+  @Modified: 2026-04-24
+-->
+
+# Shared Config Loader Contract
+
+`packages/shared/config` defines the shared runtime configuration loading contract for Dox backend runtimes.
+
+This package is a loader SDK. Callers must pass an explicit request, target, source list, and options. The package validates API usage and fails fast when the request contract is invalid.
+
+## Boundary
+
+The config package validates loader contract rules:
+
+- request shape
+- target pointer requirements
+- source descriptors
+- provider and parser naming
+- built-in provider and parser compatibility
+- option consistency
+- future error categories
+
+The config package does not validate runtime-specific setting values. That belongs to each runtime setting package, such as `server/internal/setting`.
+
+## Current Scope
+
+This milestone only defines the contract. It does not implement file loading, environment loading, parsing, merging, decoding, or remote configuration providers.

--- a/packages/shared/config/doc.go
+++ b/packages/shared/config/doc.go
@@ -1,0 +1,28 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : doc.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+// Package config defines the shared Dox runtime configuration loading contract.
+//
+// The package validates loader API usage, source descriptors, and option
+// consistency. Runtime-specific setting validation belongs to each caller.
+package config

--- a/packages/shared/config/error.go
+++ b/packages/shared/config/error.go
@@ -1,0 +1,108 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : error.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package config
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrorKind classifies loader failures without tying callers to string parsing.
+type ErrorKind string
+
+const (
+	// ErrorKindContract means the caller violated the loader API contract.
+	ErrorKindContract ErrorKind = "contract"
+	// ErrorKindSource is reserved for future provider read failures.
+	ErrorKindSource ErrorKind = "source"
+	// ErrorKindDecode is reserved for future decode failures.
+	ErrorKindDecode ErrorKind = "decode"
+)
+
+// Error describes a typed configuration loading error.
+type Error struct {
+	Kind   ErrorKind
+	Field  string
+	Reason string
+	Err    error
+}
+
+// Error returns a stable human-readable message for the configuration error.
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	message := fmt.Sprintf("config %s error", e.Kind)
+	if e.Field != "" {
+		message += " at " + e.Field
+	}
+	if e.Reason != "" {
+		message += ": " + e.Reason
+	}
+	if e.Err != nil {
+		message += ": " + e.Err.Error()
+	}
+	return message
+}
+
+// Unwrap returns the wrapped error when one is present.
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// Is reports whether the target error has the same configuration error kind.
+func (e *Error) Is(target error) bool {
+	var other *Error
+	if !errors.As(target, &other) {
+		return false
+	}
+	return e != nil && other != nil && e.Kind == other.Kind
+}
+
+// ContractError creates an error for invalid loader API usage.
+func ContractError(field string, reason string) error {
+	return &Error{Kind: ErrorKindContract, Field: field, Reason: reason}
+}
+
+// SourceError creates an error for future provider read failures.
+func SourceError(field string, reason string, err error) error {
+	return &Error{Kind: ErrorKindSource, Field: field, Reason: reason, Err: err}
+}
+
+// DecodeError creates an error for future decode failures.
+func DecodeError(field string, reason string, err error) error {
+	return &Error{Kind: ErrorKindDecode, Field: field, Reason: reason, Err: err}
+}
+
+// IsKind reports whether err contains a configuration error of the given kind.
+func IsKind(err error, kind ErrorKind) bool {
+	var cfgErr *Error
+	if !errors.As(err, &cfgErr) {
+		return false
+	}
+	return cfgErr.Kind == kind
+}

--- a/packages/shared/config/loader.go
+++ b/packages/shared/config/loader.go
@@ -1,0 +1,31 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : loader.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package config
+
+import "context"
+
+// Loader defines the future configuration loading entrypoint contract.
+type Loader interface {
+	Load(ctx context.Context, req Request) (*Result, error)
+}

--- a/packages/shared/config/types.go
+++ b/packages/shared/config/types.go
@@ -1,0 +1,123 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : types.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package config
+
+import "time"
+
+// ProviderKind identifies the provider implementation that should read a source.
+type ProviderKind string
+
+const (
+	// ProviderKindFile identifies a future local file provider.
+	ProviderKindFile ProviderKind = "file"
+	// ProviderKindEnv identifies a future environment variable provider.
+	ProviderKindEnv ProviderKind = "env"
+	// ProviderKindRemote identifies a future remote configuration provider.
+	ProviderKindRemote ProviderKind = "remote"
+)
+
+// ParserKind identifies the parser implementation for source payloads.
+type ParserKind string
+
+const (
+	// ParserKindNone means the provider already returns structured values.
+	ParserKindNone ParserKind = "none"
+	// ParserKindYAML identifies a future YAML parser.
+	ParserKindYAML ParserKind = "yaml"
+	// ParserKindJSON identifies a future JSON parser.
+	ParserKindJSON ParserKind = "json"
+	// ParserKindTOML identifies a future TOML parser.
+	ParserKindTOML ParserKind = "toml"
+)
+
+// MergeStrategy defines how values from a later source override earlier values.
+type MergeStrategy string
+
+const (
+	// MergeStrategyDeepReplace deep-merges maps and replaces scalar and slice values.
+	MergeStrategyDeepReplace MergeStrategy = "deep_replace"
+)
+
+// UnknownKeyPolicy defines how the future decoder should handle unknown fields.
+type UnknownKeyPolicy string
+
+const (
+	// UnknownKeyPolicyAllow permits keys that are not represented by the target type.
+	UnknownKeyPolicyAllow UnknownKeyPolicy = "allow"
+	// UnknownKeyPolicyReject rejects keys that are not represented by the target type.
+	UnknownKeyPolicyReject UnknownKeyPolicy = "reject"
+)
+
+// Source describes a configuration source without implementing provider reads.
+type Source struct {
+	Name     string
+	Kind     ProviderKind
+	Parser   ParserKind
+	Location string
+	Required bool
+	Priority int
+	Options  map[string]string
+}
+
+// Request describes one explicit configuration loading operation.
+type Request struct {
+	Runtime string
+	Env     string
+	Target  any
+	Sources []Source
+	Options Options
+}
+
+// Options controls future loading, merge, decode, and diagnostics behavior.
+type Options struct {
+	AllowEmptySources bool
+	MergeStrategy     MergeStrategy
+	UnknownKeyPolicy  UnknownKeyPolicy
+	Timeout           time.Duration
+	RedactKeys        []string
+}
+
+// Result describes the future output shape of a completed load.
+type Result struct {
+	Runtime     string
+	Env         string
+	SourceNames []string
+	Fingerprint string
+	Diagnostics Diagnostics
+}
+
+// Diagnostics records future source and merge metadata for operational review.
+type Diagnostics struct {
+	Sources []SourceDiagnostic
+}
+
+// SourceDiagnostic describes how one source participated in a load operation.
+type SourceDiagnostic struct {
+	Name     string
+	Kind     ProviderKind
+	Required bool
+	Loaded   bool
+	Skipped  bool
+	Message  string
+}

--- a/packages/shared/config/validate.go
+++ b/packages/shared/config/validate.go
@@ -1,0 +1,178 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : validate.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package config
+
+import (
+	"context"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var runtimeNamePattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+var envNamePattern = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+var sourceNamePattern = regexp.MustCompile(`^[a-z][a-z0-9-_.]*$`)
+var kindNamePattern = regexp.MustCompile(`^[a-z][a-z0-9-_.]*$`)
+
+// ValidateLoadRequest verifies that a loader request fails fast on API misuse.
+func ValidateLoadRequest(ctx context.Context, req Request) error {
+	if ctx == nil {
+		return ContractError("ctx", "context must not be nil")
+	}
+	if err := validateRuntime(req.Runtime); err != nil {
+		return err
+	}
+	if err := validateEnv(req.Env); err != nil {
+		return err
+	}
+	if err := validateTarget(req.Target); err != nil {
+		return err
+	}
+	if err := validateOptions(req.Options); err != nil {
+		return err
+	}
+	if !req.Options.AllowEmptySources && len(req.Sources) == 0 {
+		return ContractError("sources", "at least one source is required")
+	}
+
+	seenNames := map[string]struct{}{}
+	seenPriorities := map[int]struct{}{}
+	for index, source := range req.Sources {
+		if err := validateSource(index, source); err != nil {
+			return err
+		}
+		sourceName := strings.TrimSpace(source.Name)
+		if _, exists := seenNames[sourceName]; exists {
+			return ContractError(sourceField(index, "name"), "source name must be unique")
+		}
+		seenNames[sourceName] = struct{}{}
+		if _, exists := seenPriorities[source.Priority]; exists {
+			return ContractError(sourceField(index, "priority"), "source priority must be unique")
+		}
+		seenPriorities[source.Priority] = struct{}{}
+	}
+	return nil
+}
+
+func validateRuntime(runtime string) error {
+	runtime = strings.TrimSpace(runtime)
+	if runtime == "" {
+		return ContractError("runtime", "runtime is required")
+	}
+	if !runtimeNamePattern.MatchString(runtime) {
+		return ContractError("runtime", "runtime must use lowercase letters, digits, or hyphens and start with a letter")
+	}
+	return nil
+}
+
+func validateEnv(env string) error {
+	env = strings.TrimSpace(env)
+	if env == "" {
+		return ContractError("env", "environment is required")
+	}
+	if !envNamePattern.MatchString(env) {
+		return ContractError("env", "environment must use lowercase letters, digits, or hyphens and start with a letter")
+	}
+	return nil
+}
+
+func validateTarget(target any) error {
+	if target == nil {
+		return ContractError("target", "target must not be nil")
+	}
+	value := reflect.ValueOf(target)
+	if value.Kind() != reflect.Pointer || value.IsNil() {
+		return ContractError("target", "target must be a non-nil pointer")
+	}
+	targetKind := value.Elem().Kind()
+	switch targetKind {
+	case reflect.Struct, reflect.Map:
+	default:
+		return ContractError("target", "target must point to a struct or map")
+	}
+	return nil
+}
+
+func validateOptions(options Options) error {
+	if options.MergeStrategy == "" {
+		options.MergeStrategy = MergeStrategyDeepReplace
+	}
+	if options.MergeStrategy != MergeStrategyDeepReplace {
+		return ContractError("options.merge_strategy", "merge strategy is not supported")
+	}
+	if options.UnknownKeyPolicy == "" {
+		options.UnknownKeyPolicy = UnknownKeyPolicyReject
+	}
+	switch options.UnknownKeyPolicy {
+	case UnknownKeyPolicyAllow, UnknownKeyPolicyReject:
+	default:
+		return ContractError("options.unknown_key_policy", "unknown key policy is not supported")
+	}
+	if options.Timeout < 0 {
+		return ContractError("options.timeout", "timeout must not be negative")
+	}
+	return nil
+}
+
+func validateSource(index int, source Source) error {
+	sourceName := strings.TrimSpace(source.Name)
+	if sourceName == "" {
+		return ContractError(sourceField(index, "name"), "source name is required")
+	}
+	if !sourceNamePattern.MatchString(sourceName) {
+		return ContractError(sourceField(index, "name"), "source name must use lowercase letters, digits, hyphens, underscores, or dots and start with a letter")
+	}
+	kind := strings.TrimSpace(string(source.Kind))
+	if kind == "" {
+		return ContractError(sourceField(index, "kind"), "provider kind is required")
+	}
+	if !kindNamePattern.MatchString(kind) {
+		return ContractError(sourceField(index, "kind"), "provider kind must use lowercase letters, digits, hyphens, underscores, or dots and start with a letter")
+	}
+	parser := strings.TrimSpace(string(source.Parser))
+	if parser == "" {
+		return ContractError(sourceField(index, "parser"), "parser kind is required")
+	}
+	if !kindNamePattern.MatchString(parser) {
+		return ContractError(sourceField(index, "parser"), "parser kind must use lowercase letters, digits, hyphens, underscores, or dots and start with a letter")
+	}
+	if source.Kind == ProviderKindEnv && source.Parser != ParserKindNone {
+		return ContractError(sourceField(index, "parser"), "environment sources must use the none parser")
+	}
+	if source.Kind == ProviderKindFile && source.Parser == ParserKindNone {
+		return ContractError(sourceField(index, "parser"), "file sources must declare a parser")
+	}
+	if strings.TrimSpace(source.Location) == "" {
+		return ContractError(sourceField(index, "location"), "source location is required")
+	}
+	if source.Priority < 0 {
+		return ContractError(sourceField(index, "priority"), "priority must not be negative")
+	}
+	return nil
+}
+
+func sourceField(index int, field string) string {
+	return "sources[" + strconv.Itoa(index) + "]." + field
+}

--- a/packages/shared/config/validate_test.go
+++ b/packages/shared/config/validate_test.go
@@ -1,0 +1,206 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : validate_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package config
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type testSetting struct {
+	Name string
+}
+
+func TestValidateLoadRequestAcceptsValidContract(t *testing.T) {
+	var target testSetting
+
+	err := ValidateLoadRequest(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []Source{
+			{
+				Name:     "base",
+				Kind:     ProviderKindFile,
+				Parser:   ParserKindYAML,
+				Location: "configs/base.yaml",
+				Required: true,
+				Priority: 10,
+			},
+			{
+				Name:     "env",
+				Kind:     ProviderKindEnv,
+				Parser:   ParserKindNone,
+				Location: "DOX_SERVER_",
+				Required: false,
+				Priority: 100,
+			},
+		},
+		Options: Options{
+			MergeStrategy:    MergeStrategyDeepReplace,
+			UnknownKeyPolicy: UnknownKeyPolicyReject,
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected valid request, got %v", err)
+	}
+}
+
+func TestValidateLoadRequestRejectsNilContext(t *testing.T) {
+	var target testSetting
+
+	err := ValidateLoadRequest(nil, Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []Source{{Name: "base", Kind: ProviderKindFile, Parser: ParserKindYAML, Location: "configs/base.yaml"}},
+	})
+
+	assertContractError(t, err)
+}
+
+func TestValidateLoadRequestRejectsInvalidTarget(t *testing.T) {
+	err := ValidateLoadRequest(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  testSetting{},
+		Sources: []Source{{Name: "base", Kind: ProviderKindFile, Parser: ParserKindYAML, Location: "configs/base.yaml"}},
+	})
+
+	assertContractError(t, err)
+}
+
+func TestValidateLoadRequestRejectsEmptySourcesByDefault(t *testing.T) {
+	var target testSetting
+
+	err := ValidateLoadRequest(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+	})
+
+	assertContractError(t, err)
+}
+
+func TestValidateLoadRequestAllowsEmptySourcesWhenExplicit(t *testing.T) {
+	var target testSetting
+
+	err := ValidateLoadRequest(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Options: Options{AllowEmptySources: true},
+	})
+	if err != nil {
+		t.Fatalf("expected empty sources to be allowed, got %v", err)
+	}
+}
+
+func TestValidateLoadRequestRejectsDuplicateSourceNames(t *testing.T) {
+	var target testSetting
+
+	err := ValidateLoadRequest(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []Source{
+			{Name: "base", Kind: ProviderKindFile, Parser: ParserKindYAML, Location: "configs/base.yaml"},
+			{Name: "base", Kind: ProviderKindFile, Parser: ParserKindYAML, Location: "configs/local.yaml", Priority: 1},
+		},
+	})
+
+	assertContractError(t, err)
+}
+
+func TestValidateLoadRequestRejectsInvalidProviderParserPair(t *testing.T) {
+	var target testSetting
+
+	err := ValidateLoadRequest(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []Source{
+			{Name: "env", Kind: ProviderKindEnv, Parser: ParserKindYAML, Location: "DOX_SERVER_"},
+		},
+	})
+
+	assertContractError(t, err)
+}
+
+func TestValidateLoadRequestAllowsCustomProviderAndParserKinds(t *testing.T) {
+	var target testSetting
+
+	err := ValidateLoadRequest(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []Source{
+			{Name: "remote-main", Kind: ProviderKind("consul"), Parser: ParserKind("jsonnet"), Location: "dox/server/dev"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected custom provider and parser kinds to be accepted, got %v", err)
+	}
+}
+
+func TestValidateLoadRequestRejectsDuplicatePriorities(t *testing.T) {
+	var target testSetting
+
+	err := ValidateLoadRequest(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []Source{
+			{Name: "base", Kind: ProviderKindFile, Parser: ParserKindYAML, Location: "configs/base.yaml", Priority: 10},
+			{Name: "local", Kind: ProviderKindFile, Parser: ParserKindYAML, Location: "configs/local.yaml", Priority: 10},
+		},
+	})
+
+	assertContractError(t, err)
+}
+
+func TestErrorKindHelpers(t *testing.T) {
+	err := SourceError("source", "failed", errors.New("boom"))
+
+	if !IsKind(err, ErrorKindSource) {
+		t.Fatalf("expected source error kind, got %v", err)
+	}
+	if IsKind(err, ErrorKindContract) {
+		t.Fatal("did not expect contract error kind")
+	}
+	if !errors.Is(err, &Error{Kind: ErrorKindSource}) {
+		t.Fatal("expected errors.Is to match source error kind")
+	}
+}
+
+func assertContractError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected contract error, got nil")
+	}
+	if !IsKind(err, ErrorKindContract) {
+		t.Fatalf("expected contract error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Description

Adds the initial `packages/shared/config` contract for Dox runtime configuration loading. This PR defines the API boundary, source descriptors, options, diagnostics shape, typed error categories, and fail-fast request validation.

It intentionally does not implement file/env providers, parsing, merging, decoding, remote configuration, or runtime-specific setting validation.

## Related Links

- Closes #6

## Scope

- [ ] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [x] CI / tooling
- [ ] Security

## Implementation Notes

- Adds explicit request, source, option, result, and diagnostics contract types.
- Adds typed error categories for contract, source, and decode failures.
- Adds hand-written API contract validation for loader misuse.
- Allows custom provider and parser kind names for future plugin-style loading extensions.
- Documents that runtime-specific setting value validation belongs to caller packages such as `server/internal/setting`.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Checks:

- [x] `gofmt -w config/doc.go config/error.go config/types.go config/validate.go config/loader.go config/validate_test.go`
- [x] `GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath go test ./...` from `packages/shared`
- [x] `GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath go test ./packages/shared/... ./server/...` from repo root
- [x] `git diff --cached --check`
- [x] Signed commit verified with `git log --show-signature -1`

## Risks

This PR only establishes the config loader contract. Follow-up issues must implement providers, parser integration, merge/decode pipeline behavior, and server integration before any runtime can load real configuration through this package.