### PR TITLE
gh-8 [feat]: Add shared config local providers

### DIFF
--- a/packages/shared/config/README.md
+++ b/packages/shared/config/README.md
@@ -43,4 +43,26 @@ The config package does not validate runtime-specific setting values. That belon
 
 ## Current Scope
 
-This milestone only defines the contract. It does not implement file loading, environment loading, parsing, merging, decoding, or remote configuration providers.
+The current package defines the loader contract and local provider primitives. It includes local file and environment variable providers.
+
+It does not implement parser bodies, multi-source merge behavior, decode behavior, or remote configuration providers.
+
+## Provider Scope
+
+Local providers are responsible for reading source payloads and preserving source metadata for later pipeline stages.
+
+Providers may:
+
+- read required or optional local files;
+- read environment variables by explicit prefix;
+- return raw bytes or structured key-value payloads;
+- attach source diagnostics for later operational review.
+
+Providers must not:
+
+- merge multiple sources;
+- decode values into runtime setting structs;
+- validate runtime-specific setting values;
+- hide required source failures.
+
+Parser implementations, merge behavior, decode behavior, and remote configuration providers are separate follow-up milestones.

--- a/packages/shared/config/provider_env.go
+++ b/packages/shared/config/provider_env.go
@@ -1,0 +1,107 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : provider_env.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package config
+
+import (
+	"context"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// EnvProvider reads environment variables by explicit prefix.
+type EnvProvider struct {
+	Lookup func() []string
+}
+
+// Read filters environment variables by source location and returns structured values.
+func (p EnvProvider) Read(ctx context.Context, source Source) (*Payload, error) {
+	if ctx == nil {
+		return nil, ContractError("ctx", "context must not be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, SourceError("ctx", "context is done", err)
+	}
+	if err := validateProviderSource(source); err != nil {
+		return nil, err
+	}
+	if source.Kind != ProviderKindEnv {
+		return nil, ContractError("source.kind", "env provider requires env source kind")
+	}
+
+	var entries []string
+	if p.Lookup != nil {
+		entries = p.Lookup()
+	} else {
+		entries = os.Environ()
+	}
+	sort.Strings(entries)
+
+	values := map[string]any{}
+	prefix := source.Location
+	for _, entry := range entries {
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok || !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		normalized := normalizeEnvKey(strings.TrimPrefix(key, prefix))
+		if normalized == "" {
+			continue
+		}
+		values[normalized] = value
+	}
+	if len(values) == 0 {
+		if !source.Required {
+			return skippedPayload(source, "optional environment source did not match any variables"), nil
+		}
+		return nil, SourceError("source.location", "environment source did not match any variables", nil)
+	}
+
+	return &Payload{
+		Source: source,
+		Values: values,
+		Metadata: map[string]string{
+			"prefix": source.Location,
+			"count":  strconv.Itoa(len(values)),
+		},
+		Diagnostic: SourceDiagnostic{
+			Name:     source.Name,
+			Kind:     source.Kind,
+			Required: source.Required,
+			Loaded:   true,
+		},
+	}, nil
+}
+
+func normalizeEnvKey(key string) string {
+	key = strings.Trim(key, "_")
+	if key == "" {
+		return ""
+	}
+	key = strings.ToLower(key)
+	key = strings.ReplaceAll(key, "__", ".")
+	key = strings.ReplaceAll(key, "_", ".")
+	return key
+}

--- a/packages/shared/config/provider_file.go
+++ b/packages/shared/config/provider_file.go
@@ -1,0 +1,102 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : provider_file.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package config
+
+import (
+	"context"
+	"errors"
+	"os"
+)
+
+// FileProvider reads local configuration files as raw bytes.
+type FileProvider struct{}
+
+// Read reads the file source location and returns raw bytes for later parsing.
+func (p FileProvider) Read(ctx context.Context, source Source) (*Payload, error) {
+	if ctx == nil {
+		return nil, ContractError("ctx", "context must not be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, SourceError("ctx", "context is done", err)
+	}
+	if err := validateProviderSource(source); err != nil {
+		return nil, err
+	}
+	if source.Kind != ProviderKindFile {
+		return nil, ContractError("source.kind", "file provider requires file source kind")
+	}
+
+	info, err := os.Stat(source.Location)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) && !source.Required {
+			return skippedPayload(source, "optional file source does not exist"), nil
+		}
+		return nil, SourceError("source.location", "file source is not readable", err)
+	}
+	if info.IsDir() {
+		return nil, SourceError("source.location", "file source points to a directory", nil)
+	}
+
+	body, err := os.ReadFile(source.Location)
+	if err != nil {
+		return nil, SourceError("source.location", "file source read failed", err)
+	}
+
+	return &Payload{
+		Source:   source,
+		Raw:      body,
+		Metadata: sourceMetadata(source),
+		Diagnostic: SourceDiagnostic{
+			Name:     source.Name,
+			Kind:     source.Kind,
+			Required: source.Required,
+			Loaded:   true,
+		},
+	}, nil
+}
+
+func skippedPayload(source Source, message string) *Payload {
+	return &Payload{
+		Source:   source,
+		Metadata: sourceMetadata(source),
+		Diagnostic: SourceDiagnostic{
+			Name:     source.Name,
+			Kind:     source.Kind,
+			Required: source.Required,
+			Skipped:  true,
+			Message:  message,
+		},
+	}
+}
+
+func sourceMetadata(source Source) map[string]string {
+	switch source.Kind {
+	case ProviderKindFile:
+		return map[string]string{"path": source.Location}
+	case ProviderKindEnv:
+		return map[string]string{"prefix": source.Location, "count": "0"}
+	default:
+		return map[string]string{"location": source.Location}
+	}
+}

--- a/packages/shared/config/provider_test.go
+++ b/packages/shared/config/provider_test.go
@@ -1,0 +1,172 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : provider_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileProviderReadsRequiredFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "base.yaml")
+	if err := os.WriteFile(path, []byte("app:\n  name: dox\n"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	payload, err := FileProvider{}.Read(context.Background(), Source{
+		Name:     "base",
+		Kind:     ProviderKindFile,
+		Parser:   ParserKindYAML,
+		Location: path,
+		Required: true,
+	})
+	if err != nil {
+		t.Fatalf("read file source: %v", err)
+	}
+	if string(payload.Raw) != "app:\n  name: dox\n" {
+		t.Fatalf("unexpected raw payload: %q", payload.Raw)
+	}
+	if !payload.Diagnostic.Loaded || payload.Diagnostic.Skipped {
+		t.Fatalf("unexpected diagnostic: %+v", payload.Diagnostic)
+	}
+}
+
+func TestFileProviderRejectsMissingRequiredFile(t *testing.T) {
+	_, err := FileProvider{}.Read(context.Background(), Source{
+		Name:     "base",
+		Kind:     ProviderKindFile,
+		Parser:   ParserKindYAML,
+		Location: filepath.Join(t.TempDir(), "missing.yaml"),
+		Required: true,
+	})
+
+	if !IsKind(err, ErrorKindSource) {
+		t.Fatalf("expected source error, got %v", err)
+	}
+}
+
+func TestFileProviderSkipsMissingOptionalFile(t *testing.T) {
+	payload, err := FileProvider{}.Read(context.Background(), Source{
+		Name:     "local",
+		Kind:     ProviderKindFile,
+		Parser:   ParserKindYAML,
+		Location: filepath.Join(t.TempDir(), "missing.yaml"),
+		Required: false,
+	})
+	if err != nil {
+		t.Fatalf("expected missing optional file to be skipped, got %v", err)
+	}
+	if !payload.Diagnostic.Skipped || payload.Diagnostic.Loaded {
+		t.Fatalf("unexpected diagnostic: %+v", payload.Diagnostic)
+	}
+}
+
+func TestEnvProviderFiltersByPrefix(t *testing.T) {
+	payload, err := EnvProvider{Lookup: func() []string {
+		return []string{
+			"DOX_SERVER_APP_NAME=dox",
+			"DOX_SERVER_HTTP__ADDRESS=127.0.0.1:8080",
+			"OTHER_VALUE=ignored",
+		}
+	}}.Read(context.Background(), Source{
+		Name:     "env",
+		Kind:     ProviderKindEnv,
+		Parser:   ParserKindNone,
+		Location: "DOX_SERVER_",
+	})
+	if err != nil {
+		t.Fatalf("read env source: %v", err)
+	}
+	if got := payload.Values["app.name"]; got != "dox" {
+		t.Fatalf("expected app.name to be dox, got %v", got)
+	}
+	if got := payload.Values["http.address"]; got != "127.0.0.1:8080" {
+		t.Fatalf("expected http.address, got %v", got)
+	}
+	if _, exists := payload.Values["other.value"]; exists {
+		t.Fatal("did not expect unrelated env value")
+	}
+}
+
+func TestEnvProviderRejectsMissingRequiredValues(t *testing.T) {
+	_, err := EnvProvider{Lookup: func() []string {
+		return []string{"OTHER_VALUE=ignored"}
+	}}.Read(context.Background(), Source{
+		Name:     "env",
+		Kind:     ProviderKindEnv,
+		Parser:   ParserKindNone,
+		Location: "DOX_SERVER_",
+		Required: true,
+	})
+
+	if !IsKind(err, ErrorKindSource) {
+		t.Fatalf("expected source error, got %v", err)
+	}
+}
+
+func TestEnvProviderSkipsMissingOptionalValues(t *testing.T) {
+	payload, err := EnvProvider{Lookup: func() []string {
+		return []string{"OTHER_VALUE=ignored"}
+	}}.Read(context.Background(), Source{
+		Name:     "env",
+		Kind:     ProviderKindEnv,
+		Parser:   ParserKindNone,
+		Location: "DOX_SERVER_",
+		Required: false,
+	})
+	if err != nil {
+		t.Fatalf("expected missing optional environment values to be skipped, got %v", err)
+	}
+	if !payload.Diagnostic.Skipped || payload.Diagnostic.Loaded {
+		t.Fatalf("unexpected diagnostic: %+v", payload.Diagnostic)
+	}
+	if got := payload.Metadata["prefix"]; got != "DOX_SERVER_" {
+		t.Fatalf("expected prefix metadata, got %q", got)
+	}
+}
+
+func TestProvidersRejectInvalidSourceContracts(t *testing.T) {
+	_, err := FileProvider{}.Read(context.Background(), Source{
+		Name:     "env",
+		Kind:     ProviderKindEnv,
+		Parser:   ParserKindNone,
+		Location: "DOX_SERVER_",
+	})
+	if !IsKind(err, ErrorKindContract) {
+		t.Fatalf("expected file provider contract error, got %v", err)
+	}
+
+	_, err = EnvProvider{}.Read(context.Background(), Source{
+		Name:     "base",
+		Kind:     ProviderKindFile,
+		Parser:   ParserKindYAML,
+		Location: "configs/base.yaml",
+	})
+	if !IsKind(err, ErrorKindContract) {
+		t.Fatalf("expected env provider contract error, got %v", err)
+	}
+}

--- a/packages/shared/config/types.go
+++ b/packages/shared/config/types.go
@@ -23,15 +23,18 @@
 
 package config
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // ProviderKind identifies the provider implementation that should read a source.
 type ProviderKind string
 
 const (
-	// ProviderKindFile identifies a future local file provider.
+	// ProviderKindFile identifies the local file provider.
 	ProviderKindFile ProviderKind = "file"
-	// ProviderKindEnv identifies a future environment variable provider.
+	// ProviderKindEnv identifies the environment variable provider.
 	ProviderKindEnv ProviderKind = "env"
 	// ProviderKindRemote identifies a future remote configuration provider.
 	ProviderKindRemote ProviderKind = "remote"
@@ -69,7 +72,7 @@ const (
 	UnknownKeyPolicyReject UnknownKeyPolicy = "reject"
 )
 
-// Source describes a configuration source without implementing provider reads.
+// Source describes one configuration source for provider reads.
 type Source struct {
 	Name     string
 	Kind     ProviderKind
@@ -78,6 +81,25 @@ type Source struct {
 	Required bool
 	Priority int
 	Options  map[string]string
+}
+
+// Payload is the raw provider output that later pipeline stages parse, merge, and decode.
+type Payload struct {
+	Source     Source
+	Raw        []byte
+	Values     map[string]any
+	Metadata   map[string]string
+	Diagnostic SourceDiagnostic
+}
+
+// Provider reads one configuration source and returns a payload for later stages.
+type Provider interface {
+	Read(ctx context.Context, source Source) (*Payload, error)
+}
+
+// Parser converts provider bytes into structured values for later merge stages.
+type Parser interface {
+	Parse(ctx context.Context, payload Payload) (map[string]any, error)
 }
 
 // Request describes one explicit configuration loading operation.

--- a/packages/shared/config/validate.go
+++ b/packages/shared/config/validate.go
@@ -137,38 +137,50 @@ func validateOptions(options Options) error {
 }
 
 func validateSource(index int, source Source) error {
+	return validateSourceFields(source, func(field string) string {
+		return sourceField(index, field)
+	})
+}
+
+func validateProviderSource(source Source) error {
+	return validateSourceFields(source, func(field string) string {
+		return "source." + field
+	})
+}
+
+func validateSourceFields(source Source, fieldName func(string) string) error {
 	sourceName := strings.TrimSpace(source.Name)
 	if sourceName == "" {
-		return ContractError(sourceField(index, "name"), "source name is required")
+		return ContractError(fieldName("name"), "source name is required")
 	}
 	if !sourceNamePattern.MatchString(sourceName) {
-		return ContractError(sourceField(index, "name"), "source name must use lowercase letters, digits, hyphens, underscores, or dots and start with a letter")
+		return ContractError(fieldName("name"), "source name must use lowercase letters, digits, hyphens, underscores, or dots and start with a letter")
 	}
 	kind := strings.TrimSpace(string(source.Kind))
 	if kind == "" {
-		return ContractError(sourceField(index, "kind"), "provider kind is required")
+		return ContractError(fieldName("kind"), "provider kind is required")
 	}
 	if !kindNamePattern.MatchString(kind) {
-		return ContractError(sourceField(index, "kind"), "provider kind must use lowercase letters, digits, hyphens, underscores, or dots and start with a letter")
+		return ContractError(fieldName("kind"), "provider kind must use lowercase letters, digits, hyphens, underscores, or dots and start with a letter")
 	}
 	parser := strings.TrimSpace(string(source.Parser))
 	if parser == "" {
-		return ContractError(sourceField(index, "parser"), "parser kind is required")
+		return ContractError(fieldName("parser"), "parser kind is required")
 	}
 	if !kindNamePattern.MatchString(parser) {
-		return ContractError(sourceField(index, "parser"), "parser kind must use lowercase letters, digits, hyphens, underscores, or dots and start with a letter")
+		return ContractError(fieldName("parser"), "parser kind must use lowercase letters, digits, hyphens, underscores, or dots and start with a letter")
 	}
 	if source.Kind == ProviderKindEnv && source.Parser != ParserKindNone {
-		return ContractError(sourceField(index, "parser"), "environment sources must use the none parser")
+		return ContractError(fieldName("parser"), "environment sources must use the none parser")
 	}
 	if source.Kind == ProviderKindFile && source.Parser == ParserKindNone {
-		return ContractError(sourceField(index, "parser"), "file sources must declare a parser")
+		return ContractError(fieldName("parser"), "file sources must declare a parser")
 	}
 	if strings.TrimSpace(source.Location) == "" {
-		return ContractError(sourceField(index, "location"), "source location is required")
+		return ContractError(fieldName("location"), "source location is required")
 	}
 	if source.Priority < 0 {
-		return ContractError(sourceField(index, "priority"), "priority must not be negative")
+		return ContractError(fieldName("priority"), "priority must not be negative")
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

Adds local provider primitives to the shared config package so later loader stages can read source payloads before parsing, merging, and decoding.

## Related Links

- Closes #8
- Refs #6

## Scope

- [x] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [x] Security

## Implementation Notes

- Adds provider and parser contracts with a `Payload` shape that preserves raw bytes, structured values, metadata, and source diagnostics.
- Adds `FileProvider` for required and optional local files.
- Adds `EnvProvider` for explicit prefix filtering, including required-source failure and optional-source skip behavior.
- Keeps parser bodies, multi-source merge behavior, decode behavior, server integration, and remote configuration providers out of scope.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands and checks:

- `/home/frost/workspace/.tools/go1.25.6/bin/gofmt -w packages/shared/config/types.go packages/shared/config/validate.go packages/shared/config/provider_file.go packages/shared/config/provider_env.go packages/shared/config/provider_test.go`
- `env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go test ./packages/shared/... ./server/...`
- `env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go test ./...` from `packages/shared`
- `git diff --cached --check`
- `git log --show-signature -1 --format=fuller` verified a good GPG signature for commit `0fcdea8ea6fdd4551a7072bef55d91dadbc4da7b`

## Risks

Parser implementations, merge/decode behavior, server integration, and remote providers are intentionally deferred to follow-up issues. The env provider currently treats a required prefix with no matching variables as a source failure; if we later need empty required env overlays, that behavior should be made explicit through source options.