### PR TITLE
gh-10 [feat]: Add shared config parsers

### DIFF
--- a/packages/shared/config/README.md
+++ b/packages/shared/config/README.md
@@ -43,9 +43,9 @@ The config package does not validate runtime-specific setting values. That belon
 
 ## Current Scope
 
-The current package defines the loader contract and local provider primitives. It includes local file and environment variable providers.
+The current package defines the loader contract, local provider primitives, and local parser primitives. It includes local file providers, environment variable providers, and YAML, JSON, and TOML parsers.
 
-It does not implement parser bodies, multi-source merge behavior, decode behavior, or remote configuration providers.
+It does not implement multi-source merge behavior, decode behavior, server runtime integration, or remote configuration providers.
 
 ## Provider Scope
 
@@ -65,4 +65,22 @@ Providers must not:
 - validate runtime-specific setting values;
 - hide required source failures.
 
-Parser implementations, merge behavior, decode behavior, and remote configuration providers are separate follow-up milestones.
+## Parser Scope
+
+Parsers are responsible for converting one provider payload into structured values for later pipeline stages.
+
+Parsers may:
+
+- parse YAML, JSON, and TOML file payloads;
+- pass through structured environment provider values through the none parser;
+- report malformed payloads with typed parse errors;
+- preserve generic map-based values for later merge and decode stages.
+
+Parsers must not:
+
+- merge multiple parsed payloads;
+- decode values into runtime setting structs;
+- validate runtime-specific setting values;
+- hide malformed required source payloads.
+
+Merge behavior, decode behavior, server runtime integration, and remote configuration providers are separate follow-up milestones.

--- a/packages/shared/config/doc.go
+++ b/packages/shared/config/doc.go
@@ -24,5 +24,7 @@
 // Package config defines the shared Dox runtime configuration loading contract.
 //
 // The package validates loader API usage, source descriptors, and option
-// consistency. Runtime-specific setting validation belongs to each caller.
+// consistency. Providers read local payloads, and parsers convert local file
+// payloads into structured values. Runtime-specific setting validation belongs
+// to each caller.
 package config

--- a/packages/shared/config/error.go
+++ b/packages/shared/config/error.go
@@ -34,9 +34,11 @@ type ErrorKind string
 const (
 	// ErrorKindContract means the caller violated the loader API contract.
 	ErrorKindContract ErrorKind = "contract"
-	// ErrorKindSource is reserved for future provider read failures.
+	// ErrorKindSource means a provider could not read a declared source.
 	ErrorKindSource ErrorKind = "source"
-	// ErrorKindDecode is reserved for future decode failures.
+	// ErrorKindParse means a parser could not convert source payload data.
+	ErrorKindParse ErrorKind = "parse"
+	// ErrorKindDecode is reserved for later target decode failures.
 	ErrorKindDecode ErrorKind = "decode"
 )
 
@@ -88,9 +90,14 @@ func ContractError(field string, reason string) error {
 	return &Error{Kind: ErrorKindContract, Field: field, Reason: reason}
 }
 
-// SourceError creates an error for future provider read failures.
+// SourceError creates an error for provider read failures.
 func SourceError(field string, reason string, err error) error {
 	return &Error{Kind: ErrorKindSource, Field: field, Reason: reason, Err: err}
+}
+
+// ParseError creates an error for parser failures.
+func ParseError(field string, reason string, err error) error {
+	return &Error{Kind: ErrorKindParse, Field: field, Reason: reason, Err: err}
 }
 
 // DecodeError creates an error for future decode failures.

--- a/packages/shared/config/parser.go
+++ b/packages/shared/config/parser.go
@@ -1,0 +1,235 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : parser.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	toml "github.com/pelletier/go-toml/v2"
+	"go.yaml.in/yaml/v3"
+)
+
+// ParserFunc adapts a function into a parser implementation.
+type ParserFunc func(ctx context.Context, payload Payload) (map[string]any, error)
+
+// Parse calls f with the provided payload.
+func (f ParserFunc) Parse(ctx context.Context, payload Payload) (map[string]any, error) {
+	return f(ctx, payload)
+}
+
+// NoneParser returns structured values already produced by a provider.
+type NoneParser struct{}
+
+// Parse returns provider values for sources that do not require raw parsing.
+func (p NoneParser) Parse(ctx context.Context, payload Payload) (map[string]any, error) {
+	if err := validateParserPayload(ctx, payload, ParserKindNone); err != nil {
+		return nil, err
+	}
+	return cloneMap(payload.Values), nil
+}
+
+// JSONParser parses JSON object payloads.
+type JSONParser struct{}
+
+// Parse converts raw JSON bytes into structured values.
+func (p JSONParser) Parse(ctx context.Context, payload Payload) (map[string]any, error) {
+	if err := validateParserPayload(ctx, payload, ParserKindJSON); err != nil {
+		return nil, err
+	}
+	var root any
+	decoder := json.NewDecoder(bytes.NewReader(payload.Raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&root); err != nil {
+		return nil, ParseError(payloadField(payload, "raw"), "json parser failed", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, ParseError(payloadField(payload, "raw"), "json parser found trailing data", nil)
+		}
+		return nil, ParseError(payloadField(payload, "raw"), "json parser failed", err)
+	}
+	return parsedObject(payload, root)
+}
+
+// YAMLParser parses YAML object payloads.
+type YAMLParser struct{}
+
+// Parse converts raw YAML bytes into structured values.
+func (p YAMLParser) Parse(ctx context.Context, payload Payload) (map[string]any, error) {
+	if err := validateParserPayload(ctx, payload, ParserKindYAML); err != nil {
+		return nil, err
+	}
+	var root any
+	if err := yaml.Unmarshal(payload.Raw, &root); err != nil {
+		return nil, ParseError(payloadField(payload, "raw"), "yaml parser failed", err)
+	}
+	return parsedObject(payload, root)
+}
+
+// TOMLParser parses TOML object payloads.
+type TOMLParser struct{}
+
+// Parse converts raw TOML bytes into structured values.
+func (p TOMLParser) Parse(ctx context.Context, payload Payload) (map[string]any, error) {
+	if err := validateParserPayload(ctx, payload, ParserKindTOML); err != nil {
+		return nil, err
+	}
+	var root map[string]any
+	if err := toml.Unmarshal(payload.Raw, &root); err != nil {
+		return nil, ParseError(payloadField(payload, "raw"), "toml parser failed", err)
+	}
+	return parsedObject(payload, root)
+}
+
+// BuiltinParser returns a parser for the built-in parser kind.
+func BuiltinParser(kind ParserKind) (Parser, bool) {
+	switch kind {
+	case ParserKindNone:
+		return NoneParser{}, true
+	case ParserKindJSON:
+		return JSONParser{}, true
+	case ParserKindYAML:
+		return YAMLParser{}, true
+	case ParserKindTOML:
+		return TOMLParser{}, true
+	default:
+		return nil, false
+	}
+}
+
+// ParsePayload parses a payload with its declared built-in parser.
+func ParsePayload(ctx context.Context, payload Payload) (map[string]any, error) {
+	parser, ok := BuiltinParser(payload.Source.Parser)
+	if !ok {
+		return nil, ContractError(payloadField(payload, "parser"), "parser kind is not supported")
+	}
+	return parser.Parse(ctx, payload)
+}
+
+func validateParserPayload(ctx context.Context, payload Payload, expected ParserKind) error {
+	if ctx == nil {
+		return ContractError("ctx", "context must not be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return ParseError("ctx", "context is done", err)
+	}
+	if err := validateProviderSource(payload.Source); err != nil {
+		return err
+	}
+	if payload.Source.Parser != expected {
+		return ContractError(payloadField(payload, "parser"), "parser kind does not match parser implementation")
+	}
+	if payload.Diagnostic.Skipped {
+		return nil
+	}
+	if expected == ParserKindNone {
+		return nil
+	}
+	return nil
+}
+
+func parsedObject(payload Payload, root any) (map[string]any, error) {
+	if payload.Diagnostic.Skipped || root == nil {
+		return map[string]any{}, nil
+	}
+	normalized, err := normalizeParsedValue(root)
+	if err != nil {
+		return nil, ParseError(payloadField(payload, "raw"), "parsed value contains unsupported object keys", err)
+	}
+	values, ok := normalized.(map[string]any)
+	if !ok {
+		return nil, ParseError(payloadField(payload, "raw"), "parsed payload must be an object", nil)
+	}
+	return values, nil
+}
+
+func normalizeParsedValue(value any) (any, error) {
+	switch typed := value.(type) {
+	case map[string]any:
+		return normalizeStringMap(typed)
+	case map[any]any:
+		values := make(map[string]any, len(typed))
+		for key, entry := range typed {
+			name, ok := key.(string)
+			if !ok {
+				return nil, fmt.Errorf("non-string key %v", key)
+			}
+			normalized, err := normalizeParsedValue(entry)
+			if err != nil {
+				return nil, err
+			}
+			values[name] = normalized
+		}
+		return values, nil
+	case []any:
+		values := make([]any, len(typed))
+		for index, entry := range typed {
+			normalized, err := normalizeParsedValue(entry)
+			if err != nil {
+				return nil, err
+			}
+			values[index] = normalized
+		}
+		return values, nil
+	default:
+		return value, nil
+	}
+}
+
+func normalizeStringMap(input map[string]any) (map[string]any, error) {
+	values := make(map[string]any, len(input))
+	for key, entry := range input {
+		normalized, err := normalizeParsedValue(entry)
+		if err != nil {
+			return nil, err
+		}
+		values[key] = normalized
+	}
+	return values, nil
+}
+
+func cloneMap(input map[string]any) map[string]any {
+	if len(input) == 0 {
+		return map[string]any{}
+	}
+	values := make(map[string]any, len(input))
+	for key, value := range input {
+		values[key] = value
+	}
+	return values
+}
+
+func payloadField(payload Payload, field string) string {
+	field = strings.TrimSpace(field)
+	if payload.Source.Name == "" {
+		return "payload." + field
+	}
+	return "source." + payload.Source.Name + "." + field
+}

--- a/packages/shared/config/parser_test.go
+++ b/packages/shared/config/parser_test.go
@@ -1,0 +1,235 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : parser_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestYAMLParserParsesObjectPayload(t *testing.T) {
+	values, err := YAMLParser{}.Parse(context.Background(), filePayload(ParserKindYAML, []byte(`
+app:
+  name: dox
+http:
+  address: 127.0.0.1:8080
+features:
+  - config
+  - parser
+`)))
+	if err != nil {
+		t.Fatalf("parse yaml payload: %v", err)
+	}
+
+	app := assertMap(t, values["app"])
+	if got := app["name"]; got != "dox" {
+		t.Fatalf("expected app.name to be dox, got %v", got)
+	}
+	http := assertMap(t, values["http"])
+	if got := http["address"]; got != "127.0.0.1:8080" {
+		t.Fatalf("expected http.address, got %v", got)
+	}
+}
+
+func TestJSONParserParsesObjectPayload(t *testing.T) {
+	values, err := JSONParser{}.Parse(context.Background(), filePayload(ParserKindJSON, []byte(`{
+	"app": {"name": "dox"},
+	"http": {"port": 8080}
+}`)))
+	if err != nil {
+		t.Fatalf("parse json payload: %v", err)
+	}
+
+	app := assertMap(t, values["app"])
+	if got := app["name"]; got != "dox" {
+		t.Fatalf("expected app.name to be dox, got %v", got)
+	}
+	http := assertMap(t, values["http"])
+	if got := http["port"]; got != json.Number("8080") {
+		t.Fatalf("expected http.port to preserve json number, got %T %v", got, got)
+	}
+}
+
+func TestTOMLParserParsesObjectPayload(t *testing.T) {
+	values, err := TOMLParser{}.Parse(context.Background(), filePayload(ParserKindTOML, []byte(`
+[app]
+name = "dox"
+
+[http]
+port = 8080
+`)))
+	if err != nil {
+		t.Fatalf("parse toml payload: %v", err)
+	}
+
+	app := assertMap(t, values["app"])
+	if got := app["name"]; got != "dox" {
+		t.Fatalf("expected app.name to be dox, got %v", got)
+	}
+	http := assertMap(t, values["http"])
+	if got := http["port"]; got != int64(8080) {
+		t.Fatalf("expected http.port to be int64, got %T %v", got, got)
+	}
+}
+
+func TestNoneParserReturnsProviderValues(t *testing.T) {
+	payload := Payload{
+		Source: Source{
+			Name:     "env",
+			Kind:     ProviderKindEnv,
+			Parser:   ParserKindNone,
+			Location: "DOX_SERVER_",
+		},
+		Values: map[string]any{"app.name": "dox"},
+		Diagnostic: SourceDiagnostic{
+			Name:   "env",
+			Kind:   ProviderKindEnv,
+			Loaded: true,
+		},
+	}
+
+	values, err := NoneParser{}.Parse(context.Background(), payload)
+	if err != nil {
+		t.Fatalf("parse none payload: %v", err)
+	}
+	values["app.name"] = "changed"
+	if got := payload.Values["app.name"]; got != "dox" {
+		t.Fatalf("expected parser result to be a shallow copy, original got %v", got)
+	}
+}
+
+func TestParsePayloadUsesDeclaredBuiltinParser(t *testing.T) {
+	values, err := ParsePayload(context.Background(), filePayload(ParserKindJSON, []byte(`{"app":{"name":"dox"}}`)))
+	if err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+
+	app := assertMap(t, values["app"])
+	if got := app["name"]; got != "dox" {
+		t.Fatalf("expected app.name to be dox, got %v", got)
+	}
+}
+
+func TestParsersRejectMalformedInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		parser  Parser
+		payload Payload
+	}{
+		{
+			name:    "yaml",
+			parser:  YAMLParser{},
+			payload: filePayload(ParserKindYAML, []byte("app: [")),
+		},
+		{
+			name:    "json",
+			parser:  JSONParser{},
+			payload: filePayload(ParserKindJSON, []byte(`{"app":`)),
+		},
+		{
+			name:    "toml",
+			parser:  TOMLParser{},
+			payload: filePayload(ParserKindTOML, []byte("[app")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.parser.Parse(context.Background(), tt.payload)
+			if !IsKind(err, ErrorKindParse) {
+				t.Fatalf("expected parse error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestParserRejectsNonObjectPayload(t *testing.T) {
+	_, err := JSONParser{}.Parse(context.Background(), filePayload(ParserKindJSON, []byte(`["dox"]`)))
+
+	if !IsKind(err, ErrorKindParse) {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+}
+
+func TestParserRejectsMismatchedKind(t *testing.T) {
+	_, err := JSONParser{}.Parse(context.Background(), filePayload(ParserKindYAML, []byte(`{"app":{"name":"dox"}}`)))
+
+	if !IsKind(err, ErrorKindContract) {
+		t.Fatalf("expected contract error, got %v", err)
+	}
+}
+
+func TestParsePayloadRejectsUnsupportedParserKind(t *testing.T) {
+	_, err := ParsePayload(context.Background(), filePayload(ParserKind("jsonnet"), []byte(`{}`)))
+
+	if !IsKind(err, ErrorKindContract) {
+		t.Fatalf("expected contract error, got %v", err)
+	}
+}
+
+func TestParserSkipsOptionalPayload(t *testing.T) {
+	payload := filePayload(ParserKindYAML, nil)
+	payload.Diagnostic = SourceDiagnostic{
+		Name:    "local",
+		Kind:    ProviderKindFile,
+		Skipped: true,
+	}
+
+	values, err := YAMLParser{}.Parse(context.Background(), payload)
+	if err != nil {
+		t.Fatalf("expected skipped payload to parse as empty values, got %v", err)
+	}
+	if len(values) != 0 {
+		t.Fatalf("expected empty skipped values, got %+v", values)
+	}
+}
+
+func filePayload(parser ParserKind, raw []byte) Payload {
+	return Payload{
+		Source: Source{
+			Name:     "base",
+			Kind:     ProviderKindFile,
+			Parser:   parser,
+			Location: "configs/base",
+			Required: true,
+		},
+		Raw: raw,
+		Diagnostic: SourceDiagnostic{
+			Name:     "base",
+			Kind:     ProviderKindFile,
+			Required: true,
+			Loaded:   true,
+		},
+	}
+}
+
+func assertMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+	values, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", value)
+	}
+	return values
+}

--- a/packages/shared/config/types.go
+++ b/packages/shared/config/types.go
@@ -46,11 +46,11 @@ type ParserKind string
 const (
 	// ParserKindNone means the provider already returns structured values.
 	ParserKindNone ParserKind = "none"
-	// ParserKindYAML identifies a future YAML parser.
+	// ParserKindYAML identifies the YAML parser.
 	ParserKindYAML ParserKind = "yaml"
-	// ParserKindJSON identifies a future JSON parser.
+	// ParserKindJSON identifies the JSON parser.
 	ParserKindJSON ParserKind = "json"
-	// ParserKindTOML identifies a future TOML parser.
+	// ParserKindTOML identifies the TOML parser.
 	ParserKindTOML ParserKind = "toml"
 )
 

--- a/packages/shared/config/validate_test.go
+++ b/packages/shared/config/validate_test.go
@@ -193,6 +193,14 @@ func TestErrorKindHelpers(t *testing.T) {
 	if !errors.Is(err, &Error{Kind: ErrorKindSource}) {
 		t.Fatal("expected errors.Is to match source error kind")
 	}
+
+	parseErr := ParseError("source.base.raw", "failed", errors.New("boom"))
+	if !IsKind(parseErr, ErrorKindParse) {
+		t.Fatalf("expected parse error kind, got %v", parseErr)
+	}
+	if !errors.Is(parseErr, &Error{Kind: ErrorKindParse}) {
+		t.Fatal("expected errors.Is to match parse error kind")
+	}
 }
 
 func assertContractError(t *testing.T, err error) {

--- a/packages/shared/go.mod
+++ b/packages/shared/go.mod
@@ -1,3 +1,8 @@
 module github.com/opendox/dox/packages/shared
 
 go 1.25.6
+
+require (
+	github.com/pelletier/go-toml/v2 v2.3.0
+	go.yaml.in/yaml/v3 v3.0.4
+)

--- a/packages/shared/go.sum
+++ b/packages/shared/go.sum
@@ -1,0 +1,6 @@
+github.com/pelletier/go-toml/v2 v2.3.0 h1:k59bC/lIZREW0/iVaQR8nDHxVq8OVlIzYCOJf421CaM=
+github.com/pelletier/go-toml/v2 v2.3.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Description

Adds built-in parser support to the shared config package so provider payloads can be converted into structured values before later merge and decode stages.

## Related Links

- Closes #10
- Refs #8
- Refs #6

## Scope

- [x] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [x] Security

## Implementation Notes

- Adds `NoneParser`, `YAMLParser`, `JSONParser`, and `TOMLParser` implementations behind the existing parser contract.
- Adds `BuiltinParser` and `ParsePayload` helpers for declared built-in parser kinds.
- Adds typed parse errors so format failures stay separate from source read failures and future decode failures.
- Adds direct dependencies on `go.yaml.in/yaml/v3` and `github.com/pelletier/go-toml/v2`; JSON uses the Go standard library.
- Keeps merge behavior, decode behavior, server integration, and remote configuration providers out of scope.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands and checks:

- `/home/frost/workspace/.tools/go1.25.6/bin/gofmt -w packages/shared/config/error.go packages/shared/config/types.go packages/shared/config/parser.go packages/shared/config/parser_test.go packages/shared/config/doc.go packages/shared/config/validate_test.go`
- `env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go mod tidy` from `packages/shared`
- `env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go test -count=1 ./...` from `packages/shared`
- `env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go test -count=1 ./packages/shared/... ./server/...`
- `git diff --cached --check`
- `git log --show-signature -1 --format=fuller` verified a good GPG signature for commit `744df7cc6b21aefe4ba24d76a9d252c5f885be8c`

## Risks

The parser layer intentionally returns generic map values and does not normalize runtime setting types. Numeric type coercion and strict runtime value validation should be handled by the later merge/decode and setting validation milestones.