### PR TITLE
gh-12 [feat]: Add shared config merge support

### DIFF
--- a/packages/shared/config/README.md
+++ b/packages/shared/config/README.md
@@ -43,9 +43,9 @@ The config package does not validate runtime-specific setting values. That belon
 
 ## Current Scope
 
-The current package defines the loader contract, local provider primitives, and local parser primitives. It includes local file providers, environment variable providers, and YAML, JSON, and TOML parsers.
+The current package defines the loader contract, local provider primitives, local parser primitives, and parsed source merge primitives. It includes local file providers, environment variable providers, YAML, JSON, and TOML parsers, and Koanf-backed deep replace merge behavior.
 
-It does not implement multi-source merge behavior, decode behavior, server runtime integration, or remote configuration providers.
+It does not implement decode behavior, server runtime integration, or remote configuration providers.
 
 ## Provider Scope
 
@@ -83,4 +83,24 @@ Parsers must not:
 - validate runtime-specific setting values;
 - hide malformed required source payloads.
 
-Merge behavior, decode behavior, server runtime integration, and remote configuration providers are separate follow-up milestones.
+## Merge Scope
+
+The merge layer is responsible for combining parsed source values into one structured value map.
+
+The merge layer may:
+
+- order parsed sources by priority;
+- deep-merge nested maps;
+- replace scalars and slices from higher-priority sources;
+- expand environment provider dotted keys before merging;
+- preserve source and override diagnostics for later operational review.
+
+The merge layer must not:
+
+- decode values into runtime setting structs;
+- validate runtime-specific setting values;
+- load source payloads;
+- parse raw file bytes;
+- expose Koanf as part of the public config package contract.
+
+Decode behavior, server runtime integration, and remote configuration providers are separate follow-up milestones.

--- a/packages/shared/config/doc.go
+++ b/packages/shared/config/doc.go
@@ -24,7 +24,7 @@
 // Package config defines the shared Dox runtime configuration loading contract.
 //
 // The package validates loader API usage, source descriptors, and option
-// consistency. Providers read local payloads, and parsers convert local file
-// payloads into structured values. Runtime-specific setting validation belongs
-// to each caller.
+// consistency. Providers read local payloads, parsers convert local file
+// payloads into structured values, and mergers combine parsed source values.
+// Runtime-specific setting validation belongs to each caller.
 package config

--- a/packages/shared/config/error.go
+++ b/packages/shared/config/error.go
@@ -38,6 +38,8 @@ const (
 	ErrorKindSource ErrorKind = "source"
 	// ErrorKindParse means a parser could not convert source payload data.
 	ErrorKindParse ErrorKind = "parse"
+	// ErrorKindMerge means parsed source values could not be merged.
+	ErrorKindMerge ErrorKind = "merge"
 	// ErrorKindDecode is reserved for later target decode failures.
 	ErrorKindDecode ErrorKind = "decode"
 )
@@ -98,6 +100,11 @@ func SourceError(field string, reason string, err error) error {
 // ParseError creates an error for parser failures.
 func ParseError(field string, reason string, err error) error {
 	return &Error{Kind: ErrorKindParse, Field: field, Reason: reason, Err: err}
+}
+
+// MergeError creates an error for parsed value merge failures.
+func MergeError(field string, reason string, err error) error {
+	return &Error{Kind: ErrorKindMerge, Field: field, Reason: reason, Err: err}
 }
 
 // DecodeError creates an error for future decode failures.

--- a/packages/shared/config/merge.go
+++ b/packages/shared/config/merge.go
@@ -1,0 +1,306 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : merge.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/knadh/koanf/providers/confmap"
+	koanf "github.com/knadh/koanf/v2"
+)
+
+// DeepReplaceMerger deep-merges maps and replaces scalar or slice values.
+type DeepReplaceMerger struct{}
+
+// Merge combines parsed sources by ascending priority.
+func (m DeepReplaceMerger) Merge(ctx context.Context, sources []ParsedSource, options Options) (*MergeResult, error) {
+	if ctx == nil {
+		return nil, ContractError("ctx", "context must not be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, MergeError("ctx", "context is done", err)
+	}
+	if err := validateOptions(options); err != nil {
+		return nil, err
+	}
+
+	ordered, err := orderParsedSources(sources)
+	if err != nil {
+		return nil, err
+	}
+
+	engine := koanf.New(".")
+	result := &MergeResult{}
+	owners := map[string]string{}
+	for _, source := range ordered {
+		if err := ctx.Err(); err != nil {
+			return nil, MergeError("ctx", "context is done", err)
+		}
+		result.SourceNames = append(result.SourceNames, source.Source.Name)
+		result.Diagnostics.Sources = append(result.Diagnostics.Sources, mergeSourceDiagnostic(source))
+		if source.Diagnostic.Skipped {
+			continue
+		}
+
+		values, err := mergeSourceValues(source)
+		if err != nil {
+			return nil, err
+		}
+		incoming, err := loadSourceKoanf(source, values)
+		if err != nil {
+			return nil, err
+		}
+		incomingValues := incoming.Raw()
+		overrides := collectMergeOverrides(engine.Raw(), owners, nil, incomingValues, source.Source.Name)
+		if err := engine.Merge(incoming); err != nil {
+			return nil, MergeError(sourceMergeField(source.Source, "values"), "koanf merge failed", err)
+		}
+		setValueOwners(owners, nil, incomingValues, source.Source.Name)
+		result.Diagnostics.Overrides = append(result.Diagnostics.Overrides, overrides...)
+	}
+	result.Values = cloneStructuredMap(engine.Raw())
+	return result, nil
+}
+
+// MergeParsedSources merges parsed source values with the built-in deep replace merger.
+func MergeParsedSources(ctx context.Context, sources []ParsedSource, options Options) (*MergeResult, error) {
+	return DeepReplaceMerger{}.Merge(ctx, sources, options)
+}
+
+// ParsedSourceFromPayload binds parsed values back to the provider payload source metadata.
+func ParsedSourceFromPayload(payload Payload, values map[string]any) ParsedSource {
+	return ParsedSource{
+		Source:     payload.Source,
+		Values:     cloneStructuredMap(values),
+		Diagnostic: payload.Diagnostic,
+	}
+}
+
+func orderParsedSources(sources []ParsedSource) ([]ParsedSource, error) {
+	ordered := make([]ParsedSource, len(sources))
+	copy(ordered, sources)
+	sort.SliceStable(ordered, func(i int, j int) bool {
+		return ordered[i].Source.Priority < ordered[j].Source.Priority
+	})
+
+	seenNames := map[string]struct{}{}
+	seenPriorities := map[int]struct{}{}
+	for index, source := range ordered {
+		if err := validateProviderSource(source.Source); err != nil {
+			return nil, err
+		}
+		if _, exists := seenNames[source.Source.Name]; exists {
+			return nil, ContractError(parsedSourceField(index, "name"), "source name must be unique")
+		}
+		seenNames[source.Source.Name] = struct{}{}
+		if _, exists := seenPriorities[source.Source.Priority]; exists {
+			return nil, ContractError(parsedSourceField(index, "priority"), "source priority must be unique")
+		}
+		seenPriorities[source.Source.Priority] = struct{}{}
+	}
+	return ordered, nil
+}
+
+func mergeSourceValues(source ParsedSource) (map[string]any, error) {
+	values := cloneStructuredMap(source.Values)
+	if source.Source.Kind != ProviderKindEnv || source.Source.Parser != ParserKindNone {
+		return values, nil
+	}
+	expanded, err := expandDottedValues(values)
+	if err != nil {
+		return nil, MergeError(sourceMergeField(source.Source, "values"), "environment source values are not expandable", err)
+	}
+	return expanded, nil
+}
+
+func loadSourceKoanf(source ParsedSource, values map[string]any) (*koanf.Koanf, error) {
+	sourceConfig := koanf.New(".")
+	if err := sourceConfig.Load(confmap.Provider(values, ""), nil); err != nil {
+		return nil, MergeError(sourceMergeField(source.Source, "values"), "koanf source load failed", err)
+	}
+	return sourceConfig, nil
+}
+
+func collectMergeOverrides(current map[string]any, owners map[string]string, path []string, incoming map[string]any, sourceName string) []MergeOverride {
+	var overrides []MergeOverride
+	keys := sortedMapKeys(incoming)
+	for _, key := range keys {
+		nextPath := appendPath(path, key)
+		incomingValue := incoming[key]
+		existingValue, exists := current[key]
+
+		incomingMap, incomingIsMap := incomingValue.(map[string]any)
+		existingMap, existingIsMap := existingValue.(map[string]any)
+		if exists && incomingIsMap && existingIsMap {
+			nestedOverrides := collectMergeOverrides(existingMap, owners, nextPath, incomingMap, sourceName)
+			overrides = append(overrides, nestedOverrides...)
+			continue
+		}
+
+		if exists && !reflect.DeepEqual(existingValue, incomingValue) {
+			previousSource := ownerForPath(owners, nextPath)
+			if previousSource != "" && previousSource != sourceName {
+				overrides = append(overrides, MergeOverride{
+					Path:           strings.Join(nextPath, "."),
+					Source:         sourceName,
+					PreviousSource: previousSource,
+				})
+			}
+		}
+	}
+	return overrides
+}
+
+func expandDottedValues(values map[string]any) (map[string]any, error) {
+	expanded := map[string]any{}
+	keys := sortedMapKeys(values)
+	for _, key := range keys {
+		parts := strings.Split(key, ".")
+		for _, part := range parts {
+			if strings.TrimSpace(part) == "" {
+				return nil, fmt.Errorf("empty path segment in %q", key)
+			}
+		}
+		if err := setDottedValue(expanded, parts, cloneStructuredValue(values[key])); err != nil {
+			return nil, err
+		}
+	}
+	return expanded, nil
+}
+
+func setDottedValue(values map[string]any, path []string, value any) error {
+	if len(path) == 1 {
+		if existing, exists := values[path[0]]; exists && !reflect.DeepEqual(existing, value) {
+			return fmt.Errorf("conflicting value for %q", strings.Join(path, "."))
+		}
+		values[path[0]] = value
+		return nil
+	}
+	head := path[0]
+	next, exists := values[head]
+	if !exists {
+		child := map[string]any{}
+		values[head] = child
+		return setDottedValue(child, path[1:], value)
+	}
+	child, ok := next.(map[string]any)
+	if !ok {
+		return fmt.Errorf("conflicting scalar at %q", head)
+	}
+	return setDottedValue(child, path[1:], value)
+}
+
+func mergeSourceDiagnostic(source ParsedSource) SourceDiagnostic {
+	diagnostic := source.Diagnostic
+	if diagnostic.Name == "" {
+		diagnostic.Name = source.Source.Name
+	}
+	if diagnostic.Kind == "" {
+		diagnostic.Kind = source.Source.Kind
+	}
+	if !diagnostic.Required {
+		diagnostic.Required = source.Source.Required
+	}
+	if !diagnostic.Loaded && !diagnostic.Skipped && len(source.Values) > 0 {
+		diagnostic.Loaded = true
+	}
+	return diagnostic
+}
+
+func ownerForPath(owners map[string]string, path []string) string {
+	for len(path) > 0 {
+		if owner := owners[strings.Join(path, ".")]; owner != "" {
+			return owner
+		}
+		path = path[:len(path)-1]
+	}
+	return ""
+}
+
+func setValueOwners(owners map[string]string, path []string, value any, sourceName string) {
+	joined := strings.Join(path, ".")
+	owners[joined] = sourceName
+	if values, ok := value.(map[string]any); ok {
+		for _, key := range sortedMapKeys(values) {
+			setValueOwners(owners, appendPath(path, key), values[key], sourceName)
+		}
+	}
+}
+
+func cloneStructuredMap(input map[string]any) map[string]any {
+	if len(input) == 0 {
+		return map[string]any{}
+	}
+	values := make(map[string]any, len(input))
+	for key, value := range input {
+		values[key] = cloneStructuredValue(value)
+	}
+	return values
+}
+
+func cloneStructuredValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneStructuredMap(typed)
+	case []any:
+		values := make([]any, len(typed))
+		for index, entry := range typed {
+			values[index] = cloneStructuredValue(entry)
+		}
+		return values
+	default:
+		return value
+	}
+}
+
+func sortedMapKeys(values map[string]any) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func appendPath(path []string, key string) []string {
+	next := make([]string, 0, len(path)+1)
+	next = append(next, path...)
+	next = append(next, key)
+	return next
+}
+
+func parsedSourceField(index int, field string) string {
+	return "parsed_sources[" + fmt.Sprint(index) + "].source." + field
+}
+
+func sourceMergeField(source Source, field string) string {
+	if source.Name == "" {
+		return "source." + field
+	}
+	return "source." + source.Name + "." + field
+}

--- a/packages/shared/config/merge_test.go
+++ b/packages/shared/config/merge_test.go
@@ -1,0 +1,250 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : merge_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-24
+ * @Modified: 2026-04-24
+ */
+
+package config
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestMergeParsedSourcesDeepMergesByPriority(t *testing.T) {
+	result, err := MergeParsedSources(context.Background(), []ParsedSource{
+		parsedFileSource("local", 20, map[string]any{
+			"app": map[string]any{
+				"debug": true,
+			},
+			"http": map[string]any{
+				"timeout": "10s",
+			},
+		}),
+		parsedFileSource("base", 10, map[string]any{
+			"app": map[string]any{
+				"name": "dox",
+			},
+			"http": map[string]any{
+				"address": "127.0.0.1:8080",
+				"timeout": "5s",
+			},
+		}),
+	}, Options{})
+	if err != nil {
+		t.Fatalf("merge parsed sources: %v", err)
+	}
+
+	if !reflect.DeepEqual(result.SourceNames, []string{"base", "local"}) {
+		t.Fatalf("unexpected source names: %+v", result.SourceNames)
+	}
+	app := assertMap(t, result.Values["app"])
+	if got := app["name"]; got != "dox" {
+		t.Fatalf("expected app.name from base, got %v", got)
+	}
+	if got := app["debug"]; got != true {
+		t.Fatalf("expected app.debug from local, got %v", got)
+	}
+	http := assertMap(t, result.Values["http"])
+	if got := http["address"]; got != "127.0.0.1:8080" {
+		t.Fatalf("expected http.address from base, got %v", got)
+	}
+	if got := http["timeout"]; got != "10s" {
+		t.Fatalf("expected http.timeout override from local, got %v", got)
+	}
+	assertOverride(t, result.Diagnostics.Overrides, "http.timeout", "local", "base")
+}
+
+func TestMergeParsedSourcesReplacesScalarsAndSlices(t *testing.T) {
+	result, err := MergeParsedSources(context.Background(), []ParsedSource{
+		parsedFileSource("base", 10, map[string]any{
+			"mode":     "prod",
+			"features": []any{"base", "audit"},
+		}),
+		parsedFileSource("local", 20, map[string]any{
+			"mode":     "dev",
+			"features": []any{"local"},
+		}),
+	}, Options{})
+	if err != nil {
+		t.Fatalf("merge parsed sources: %v", err)
+	}
+
+	if got := result.Values["mode"]; got != "dev" {
+		t.Fatalf("expected scalar override, got %v", got)
+	}
+	if got := result.Values["features"]; !reflect.DeepEqual(got, []any{"local"}) {
+		t.Fatalf("expected slice replacement, got %+v", got)
+	}
+	assertOverride(t, result.Diagnostics.Overrides, "mode", "local", "base")
+	assertOverride(t, result.Diagnostics.Overrides, "features", "local", "base")
+}
+
+func TestMergeParsedSourcesExpandsEnvironmentDottedKeys(t *testing.T) {
+	result, err := MergeParsedSources(context.Background(), []ParsedSource{
+		parsedFileSource("base", 10, map[string]any{
+			"app": map[string]any{
+				"name": "dox",
+			},
+			"http": map[string]any{
+				"address": "127.0.0.1:8080",
+			},
+		}),
+		parsedEnvSource("env", 100, map[string]any{
+			"app.name":     "dox-env",
+			"http.address": "0.0.0.0:8080",
+		}),
+	}, Options{})
+	if err != nil {
+		t.Fatalf("merge parsed sources: %v", err)
+	}
+
+	app := assertMap(t, result.Values["app"])
+	if got := app["name"]; got != "dox-env" {
+		t.Fatalf("expected env app.name override, got %v", got)
+	}
+	http := assertMap(t, result.Values["http"])
+	if got := http["address"]; got != "0.0.0.0:8080" {
+		t.Fatalf("expected env http.address override, got %v", got)
+	}
+	assertOverride(t, result.Diagnostics.Overrides, "app.name", "env", "base")
+	assertOverride(t, result.Diagnostics.Overrides, "http.address", "env", "base")
+}
+
+func TestMergeParsedSourcesKeepsSkippedSourceDiagnostics(t *testing.T) {
+	result, err := MergeParsedSources(context.Background(), []ParsedSource{
+		parsedFileSource("base", 10, map[string]any{"app": map[string]any{"name": "dox"}}),
+		skippedFileSource("local", 20),
+	}, Options{})
+	if err != nil {
+		t.Fatalf("merge parsed sources: %v", err)
+	}
+
+	if !reflect.DeepEqual(result.SourceNames, []string{"base", "local"}) {
+		t.Fatalf("unexpected source names: %+v", result.SourceNames)
+	}
+	if len(result.Diagnostics.Sources) != 2 {
+		t.Fatalf("expected two source diagnostics, got %+v", result.Diagnostics.Sources)
+	}
+	if !result.Diagnostics.Sources[1].Skipped {
+		t.Fatalf("expected skipped diagnostic, got %+v", result.Diagnostics.Sources[1])
+	}
+	app := assertMap(t, result.Values["app"])
+	if got := app["name"]; got != "dox" {
+		t.Fatalf("expected skipped source not to override values, got %v", got)
+	}
+}
+
+func TestMergeParsedSourcesRejectsDuplicatePriorities(t *testing.T) {
+	_, err := MergeParsedSources(context.Background(), []ParsedSource{
+		parsedFileSource("base", 10, map[string]any{}),
+		parsedFileSource("local", 10, map[string]any{}),
+	}, Options{})
+
+	if !IsKind(err, ErrorKindContract) {
+		t.Fatalf("expected contract error, got %v", err)
+	}
+}
+
+func TestMergeParsedSourcesRejectsConflictingEnvironmentDottedKeys(t *testing.T) {
+	_, err := MergeParsedSources(context.Background(), []ParsedSource{
+		parsedEnvSource("env", 10, map[string]any{
+			"app":      "dox",
+			"app.name": "dox",
+		}),
+	}, Options{})
+
+	if !IsKind(err, ErrorKindMerge) {
+		t.Fatalf("expected merge error, got %v", err)
+	}
+}
+
+func TestMergeErrorKindHelpers(t *testing.T) {
+	err := MergeError("source.base.values", "failed", errors.New("boom"))
+
+	if !IsKind(err, ErrorKindMerge) {
+		t.Fatalf("expected merge error kind, got %v", err)
+	}
+	if !errors.Is(err, &Error{Kind: ErrorKindMerge}) {
+		t.Fatal("expected errors.Is to match merge error kind")
+	}
+}
+
+func parsedFileSource(name string, priority int, values map[string]any) ParsedSource {
+	return ParsedSource{
+		Source: Source{
+			Name:     name,
+			Kind:     ProviderKindFile,
+			Parser:   ParserKindYAML,
+			Location: "configs/" + name + ".yaml",
+			Required: true,
+			Priority: priority,
+		},
+		Values: values,
+		Diagnostic: SourceDiagnostic{
+			Name:     name,
+			Kind:     ProviderKindFile,
+			Required: true,
+			Loaded:   true,
+		},
+	}
+}
+
+func parsedEnvSource(name string, priority int, values map[string]any) ParsedSource {
+	return ParsedSource{
+		Source: Source{
+			Name:     name,
+			Kind:     ProviderKindEnv,
+			Parser:   ParserKindNone,
+			Location: "DOX_SERVER_",
+			Priority: priority,
+		},
+		Values: values,
+		Diagnostic: SourceDiagnostic{
+			Name:   name,
+			Kind:   ProviderKindEnv,
+			Loaded: true,
+		},
+	}
+}
+
+func skippedFileSource(name string, priority int) ParsedSource {
+	source := parsedFileSource(name, priority, nil)
+	source.Source.Required = false
+	source.Diagnostic = SourceDiagnostic{
+		Name:    name,
+		Kind:    ProviderKindFile,
+		Skipped: true,
+		Message: "optional file source does not exist",
+	}
+	return source
+}
+
+func assertOverride(t *testing.T, overrides []MergeOverride, path string, source string, previousSource string) {
+	t.Helper()
+	for _, override := range overrides {
+		if override.Path == path && override.Source == source && override.PreviousSource == previousSource {
+			return
+		}
+	}
+	t.Fatalf("expected override %s %s <- %s in %+v", path, source, previousSource, overrides)
+}

--- a/packages/shared/config/types.go
+++ b/packages/shared/config/types.go
@@ -102,6 +102,25 @@ type Parser interface {
 	Parse(ctx context.Context, payload Payload) (map[string]any, error)
 }
 
+// ParsedSource is one provider source after parser output is available.
+type ParsedSource struct {
+	Source     Source
+	Values     map[string]any
+	Diagnostic SourceDiagnostic
+}
+
+// Merger combines parsed sources into one structured value map.
+type Merger interface {
+	Merge(ctx context.Context, sources []ParsedSource, options Options) (*MergeResult, error)
+}
+
+// MergeResult describes the output of a parsed source merge operation.
+type MergeResult struct {
+	Values      map[string]any
+	SourceNames []string
+	Diagnostics Diagnostics
+}
+
 // Request describes one explicit configuration loading operation.
 type Request struct {
 	Runtime string
@@ -131,7 +150,8 @@ type Result struct {
 
 // Diagnostics records future source and merge metadata for operational review.
 type Diagnostics struct {
-	Sources []SourceDiagnostic
+	Sources   []SourceDiagnostic
+	Overrides []MergeOverride
 }
 
 // SourceDiagnostic describes how one source participated in a load operation.
@@ -142,4 +162,11 @@ type SourceDiagnostic struct {
 	Loaded   bool
 	Skipped  bool
 	Message  string
+}
+
+// MergeOverride records which source replaced a previously merged value.
+type MergeOverride struct {
+	Path           string
+	Source         string
+	PreviousSource string
 }

--- a/packages/shared/go.mod
+++ b/packages/shared/go.mod
@@ -3,6 +3,15 @@ module github.com/opendox/dox/packages/shared
 go 1.25.6
 
 require (
+	github.com/knadh/koanf/providers/confmap v1.0.0
+	github.com/knadh/koanf/v2 v2.3.4
 	github.com/pelletier/go-toml/v2 v2.3.0
 	go.yaml.in/yaml/v3 v3.0.4
+)
+
+require (
+	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/knadh/koanf/maps v0.1.2 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 )

--- a/packages/shared/go.sum
+++ b/packages/shared/go.sum
@@ -1,3 +1,15 @@
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/knadh/koanf/maps v0.1.2 h1:RBfmAW5CnZT+PJ1CVc1QSJKf4Xu9kxfQgYVQSu8hpbo=
+github.com/knadh/koanf/maps v0.1.2/go.mod h1:npD/QZY3V6ghQDdcQzl1W4ICNVTkohC8E73eI2xW4yI=
+github.com/knadh/koanf/providers/confmap v1.0.0 h1:mHKLJTE7iXEys6deO5p6olAiZdG5zwp8Aebir+/EaRE=
+github.com/knadh/koanf/providers/confmap v1.0.0/go.mod h1:txHYHiI2hAtF0/0sCmcuol4IDcuQbKTybiB1nOcUo1A=
+github.com/knadh/koanf/v2 v2.3.4 h1:fnynNSDlujWE+v83hAp8wKr/cdoxHLO0629SN+U8Urc=
+github.com/knadh/koanf/v2 v2.3.4/go.mod h1:gRb40VRAbd4iJMYYD5IxZ6hfuopFcXBpc9bbQpZwo28=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/pelletier/go-toml/v2 v2.3.0 h1:k59bC/lIZREW0/iVaQR8nDHxVq8OVlIzYCOJf421CaM=
 github.com/pelletier/go-toml/v2 v2.3.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=


### PR DESCRIPTION
## Description

Adds parsed source merge support to the shared config package so provider/parser output can be combined into one deterministic configuration map before future decode and runtime setting validation stages.

## Related Links

- Closes #12
- Refs #10
- Refs #8
- Refs #6

## Scope

- [x] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [x] Security

## Implementation Notes

- Adds `ParsedSource`, `Merger`, `MergeResult`, and merge override diagnostics to the shared config contract.
- Adds `DeepReplaceMerger` and `MergeParsedSources` for priority-ordered source merging.
- Uses Koanf internally as the merge engine through `github.com/knadh/koanf/v2` and `confmap`, without exposing Koanf in the public config API.
- Expands environment provider dotted keys before merging so env overlays can override nested file configuration.
- Preserves source ordering, skipped optional source diagnostics, and override records.
- Keeps decode behavior, server integration, file watching, and remote configuration providers out of scope.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands and checks:

- `/home/frost/workspace/.tools/go1.25.6/bin/gofmt -w packages/shared/config/merge.go packages/shared/config/merge_test.go packages/shared/config/error.go packages/shared/config/types.go packages/shared/config/doc.go`
- `env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go mod tidy` from `packages/shared`
- `env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go test -count=1 ./packages/shared/... ./server/...`
- `git diff --cached --check`
- `git log --show-signature -1 --format=fuller` verified a good GPG signature for commit `a8f5efc64a3714d46e2a3e155f0e9bc9dc0372a1`

## Risks

Koanf is intentionally scoped to internal merge behavior. The public config package still owns the contract, diagnostics, and future pipeline boundaries. Decode behavior and runtime setting validation remain separate milestones.