### PR TITLE
gh-14 [feat]: Add shared config decode support

### DIFF
--- a/packages/shared/config/README.md
+++ b/packages/shared/config/README.md
@@ -43,9 +43,9 @@ The config package does not validate runtime-specific setting values. That belon
 
 ## Current Scope
 
-The current package defines the loader contract, local provider primitives, local parser primitives, and parsed source merge primitives. It includes local file providers, environment variable providers, YAML, JSON, and TOML parsers, and Koanf-backed deep replace merge behavior.
+The current package defines the loader contract, local provider primitives, local parser primitives, parsed source merge primitives, and merged value decode primitives. It includes local file providers, environment variable providers, YAML, JSON, and TOML parsers, Koanf-backed deep replace merge behavior, and mapstructure-backed decode behavior.
 
-It does not implement decode behavior, server runtime integration, or remote configuration providers.
+It does not implement server runtime integration or remote configuration providers.
 
 ## Provider Scope
 
@@ -103,4 +103,23 @@ The merge layer must not:
 - parse raw file bytes;
 - expose Koanf as part of the public config package contract.
 
-Decode behavior, server runtime integration, and remote configuration providers are separate follow-up milestones.
+## Decode Scope
+
+The decode layer is responsible for copying merged values into a caller-provided target.
+
+The decode layer may:
+
+- decode merged values into struct pointers;
+- decode merged values into map pointers;
+- apply the unknown key policy contract;
+- perform generic type conversions needed to populate target fields;
+- report typed decode errors for target conversion failures.
+
+The decode layer must not:
+
+- validate runtime-specific setting values;
+- create runtime-specific setting types;
+- orchestrate provider, parser, merge, and decode stages;
+- expose mapstructure as part of the public config package contract.
+
+Server runtime integration and remote configuration providers are separate follow-up milestones.

--- a/packages/shared/config/decode.go
+++ b/packages/shared/config/decode.go
@@ -1,0 +1,81 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : decode.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-25
+ * @Modified: 2026-04-25
+ */
+
+package config
+
+import (
+	"context"
+
+	"github.com/go-viper/mapstructure/v2"
+)
+
+// MapstructureDecoder decodes merged values into caller-owned targets.
+type MapstructureDecoder struct{}
+
+// Decode copies merged values into target according to decode options.
+func (d MapstructureDecoder) Decode(ctx context.Context, values map[string]any, target any, options Options) error {
+	if ctx == nil {
+		return ContractError("ctx", "context must not be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return DecodeError("ctx", "context is done", err)
+	}
+	if err := validateTarget(target); err != nil {
+		return err
+	}
+	normalizedOptions, err := normalizeOptions(options)
+	if err != nil {
+		return err
+	}
+
+	metadata := &mapstructure.Metadata{}
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook:       mapstructure.StringToTimeDurationHookFunc(),
+		ErrorUnused:      normalizedOptions.UnknownKeyPolicy == UnknownKeyPolicyReject,
+		Metadata:         metadata,
+		Result:           target,
+		TagName:          "mapstructure",
+		WeaklyTypedInput: true,
+		ZeroFields:       true,
+	})
+	if err != nil {
+		return DecodeError("target", "decoder initialization failed", err)
+	}
+	if err := decoder.Decode(cloneStructuredMap(values)); err != nil {
+		return DecodeError("target", "decode failed", err)
+	}
+	return nil
+}
+
+// DecodeValues decodes merged values with the built-in decoder.
+func DecodeValues(ctx context.Context, values map[string]any, target any, options Options) error {
+	return MapstructureDecoder{}.Decode(ctx, values, target, options)
+}
+
+// DecodeMergeResult decodes a merge result with the built-in decoder.
+func DecodeMergeResult(ctx context.Context, result *MergeResult, target any, options Options) error {
+	if result == nil {
+		return ContractError("result", "merge result must not be nil")
+	}
+	return DecodeValues(ctx, result.Values, target, options)
+}

--- a/packages/shared/config/decode_test.go
+++ b/packages/shared/config/decode_test.go
@@ -1,0 +1,181 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : decode_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-25
+ * @Modified: 2026-04-25
+ */
+
+package config
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type decodeSetting struct {
+	App  decodeAppSetting  `mapstructure:"app"`
+	HTTP decodeHTTPSetting `mapstructure:"http"`
+}
+
+type decodeAppSetting struct {
+	Name string `mapstructure:"name"`
+}
+
+type decodeHTTPSetting struct {
+	Port    int           `mapstructure:"port"`
+	Timeout time.Duration `mapstructure:"timeout"`
+}
+
+func TestDecodeValuesDecodesStructTarget(t *testing.T) {
+	var target decodeSetting
+
+	err := DecodeValues(context.Background(), map[string]any{
+		"app": map[string]any{
+			"name": "dox",
+		},
+		"http": map[string]any{
+			"port":    "8080",
+			"timeout": "5s",
+		},
+	}, &target, Options{UnknownKeyPolicy: UnknownKeyPolicyReject})
+	if err != nil {
+		t.Fatalf("decode values: %v", err)
+	}
+
+	if target.App.Name != "dox" {
+		t.Fatalf("expected app.name to be decoded, got %q", target.App.Name)
+	}
+	if target.HTTP.Port != 8080 {
+		t.Fatalf("expected weak string port decode, got %d", target.HTTP.Port)
+	}
+	if target.HTTP.Timeout != 5*time.Second {
+		t.Fatalf("expected duration decode, got %s", target.HTTP.Timeout)
+	}
+}
+
+func TestDecodeValuesDecodesMapTarget(t *testing.T) {
+	var target map[string]any
+
+	err := DecodeValues(context.Background(), map[string]any{
+		"app": map[string]any{
+			"name": "dox",
+		},
+	}, &target, Options{})
+	if err != nil {
+		t.Fatalf("decode map target: %v", err)
+	}
+
+	app := assertMap(t, target["app"])
+	if got := app["name"]; got != "dox" {
+		t.Fatalf("expected app.name to be dox, got %v", got)
+	}
+}
+
+func TestDecodeMergeResultDecodesValues(t *testing.T) {
+	var target decodeSetting
+
+	err := DecodeMergeResult(context.Background(), &MergeResult{
+		Values: map[string]any{
+			"app": map[string]any{"name": "dox"},
+		},
+	}, &target, Options{UnknownKeyPolicy: UnknownKeyPolicyAllow})
+	if err != nil {
+		t.Fatalf("decode merge result: %v", err)
+	}
+	if target.App.Name != "dox" {
+		t.Fatalf("expected app.name to be dox, got %q", target.App.Name)
+	}
+}
+
+func TestDecodeValuesRejectsInvalidTarget(t *testing.T) {
+	err := DecodeValues(context.Background(), map[string]any{}, decodeSetting{}, Options{})
+
+	if !IsKind(err, ErrorKindContract) {
+		t.Fatalf("expected contract error, got %v", err)
+	}
+}
+
+func TestDecodeValuesRejectsUnknownKeysByDefault(t *testing.T) {
+	var target decodeSetting
+
+	err := DecodeValues(context.Background(), map[string]any{
+		"app": map[string]any{
+			"name":  "dox",
+			"extra": true,
+		},
+	}, &target, Options{})
+
+	if !IsKind(err, ErrorKindDecode) {
+		t.Fatalf("expected decode error, got %v", err)
+	}
+}
+
+func TestDecodeValuesAllowsUnknownKeysWhenExplicit(t *testing.T) {
+	var target decodeSetting
+
+	err := DecodeValues(context.Background(), map[string]any{
+		"app": map[string]any{
+			"name":  "dox",
+			"extra": true,
+		},
+	}, &target, Options{UnknownKeyPolicy: UnknownKeyPolicyAllow})
+	if err != nil {
+		t.Fatalf("expected unknown key allow to decode, got %v", err)
+	}
+	if target.App.Name != "dox" {
+		t.Fatalf("expected app.name to be decoded, got %q", target.App.Name)
+	}
+}
+
+func TestDecodeValuesReturnsDecodeErrorForInvalidFieldType(t *testing.T) {
+	var target decodeSetting
+
+	err := DecodeValues(context.Background(), map[string]any{
+		"http": map[string]any{
+			"port": "not-a-number",
+		},
+	}, &target, Options{UnknownKeyPolicy: UnknownKeyPolicyAllow})
+
+	if !IsKind(err, ErrorKindDecode) {
+		t.Fatalf("expected decode error, got %v", err)
+	}
+}
+
+func TestDecodeMergeResultRejectsNilResult(t *testing.T) {
+	var target decodeSetting
+
+	err := DecodeMergeResult(context.Background(), nil, &target, Options{})
+
+	if !IsKind(err, ErrorKindContract) {
+		t.Fatalf("expected contract error, got %v", err)
+	}
+}
+
+func TestDecodeErrorKindHelpers(t *testing.T) {
+	err := DecodeError("target", "failed", errors.New("boom"))
+
+	if !IsKind(err, ErrorKindDecode) {
+		t.Fatalf("expected decode error kind, got %v", err)
+	}
+	if !errors.Is(err, &Error{Kind: ErrorKindDecode}) {
+		t.Fatal("expected errors.Is to match decode error kind")
+	}
+}

--- a/packages/shared/config/doc.go
+++ b/packages/shared/config/doc.go
@@ -25,6 +25,7 @@
 //
 // The package validates loader API usage, source descriptors, and option
 // consistency. Providers read local payloads, parsers convert local file
-// payloads into structured values, and mergers combine parsed source values.
-// Runtime-specific setting validation belongs to each caller.
+// payloads into structured values, mergers combine parsed source values, and
+// decoders copy merged values into caller-owned targets. Runtime-specific
+// setting validation belongs to each caller.
 package config

--- a/packages/shared/config/error.go
+++ b/packages/shared/config/error.go
@@ -40,7 +40,7 @@ const (
 	ErrorKindParse ErrorKind = "parse"
 	// ErrorKindMerge means parsed source values could not be merged.
 	ErrorKindMerge ErrorKind = "merge"
-	// ErrorKindDecode is reserved for later target decode failures.
+	// ErrorKindDecode means merged values could not be decoded into a target.
 	ErrorKindDecode ErrorKind = "decode"
 )
 
@@ -107,7 +107,7 @@ func MergeError(field string, reason string, err error) error {
 	return &Error{Kind: ErrorKindMerge, Field: field, Reason: reason, Err: err}
 }
 
-// DecodeError creates an error for future decode failures.
+// DecodeError creates an error for target decode failures.
 func DecodeError(field string, reason string, err error) error {
 	return &Error{Kind: ErrorKindDecode, Field: field, Reason: reason, Err: err}
 }

--- a/packages/shared/config/types.go
+++ b/packages/shared/config/types.go
@@ -114,6 +114,11 @@ type Merger interface {
 	Merge(ctx context.Context, sources []ParsedSource, options Options) (*MergeResult, error)
 }
 
+// Decoder copies merged configuration values into a caller-provided target.
+type Decoder interface {
+	Decode(ctx context.Context, values map[string]any, target any, options Options) error
+}
+
 // MergeResult describes the output of a parsed source merge operation.
 type MergeResult struct {
 	Values      map[string]any

--- a/packages/shared/config/validate.go
+++ b/packages/shared/config/validate.go
@@ -116,11 +116,16 @@ func validateTarget(target any) error {
 }
 
 func validateOptions(options Options) error {
+	_, err := normalizeOptions(options)
+	return err
+}
+
+func normalizeOptions(options Options) (Options, error) {
 	if options.MergeStrategy == "" {
 		options.MergeStrategy = MergeStrategyDeepReplace
 	}
 	if options.MergeStrategy != MergeStrategyDeepReplace {
-		return ContractError("options.merge_strategy", "merge strategy is not supported")
+		return options, ContractError("options.merge_strategy", "merge strategy is not supported")
 	}
 	if options.UnknownKeyPolicy == "" {
 		options.UnknownKeyPolicy = UnknownKeyPolicyReject
@@ -128,12 +133,12 @@ func validateOptions(options Options) error {
 	switch options.UnknownKeyPolicy {
 	case UnknownKeyPolicyAllow, UnknownKeyPolicyReject:
 	default:
-		return ContractError("options.unknown_key_policy", "unknown key policy is not supported")
+		return options, ContractError("options.unknown_key_policy", "unknown key policy is not supported")
 	}
 	if options.Timeout < 0 {
-		return ContractError("options.timeout", "timeout must not be negative")
+		return options, ContractError("options.timeout", "timeout must not be negative")
 	}
-	return nil
+	return options, nil
 }
 
 func validateSource(index int, source Source) error {

--- a/packages/shared/go.mod
+++ b/packages/shared/go.mod
@@ -3,6 +3,7 @@ module github.com/opendox/dox/packages/shared
 go 1.25.6
 
 require (
+	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/knadh/koanf/providers/confmap v1.0.0
 	github.com/knadh/koanf/v2 v2.3.4
 	github.com/pelletier/go-toml/v2 v2.3.0
@@ -10,7 +11,6 @@ require (
 )
 
 require (
-	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/packages/shared/go.sum
+++ b/packages/shared/go.sum
@@ -1,5 +1,5 @@
-github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
-github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
+github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/knadh/koanf/maps v0.1.2 h1:RBfmAW5CnZT+PJ1CVc1QSJKf4Xu9kxfQgYVQSu8hpbo=
 github.com/knadh/koanf/maps v0.1.2/go.mod h1:npD/QZY3V6ghQDdcQzl1W4ICNVTkohC8E73eI2xW4yI=
 github.com/knadh/koanf/providers/confmap v1.0.0 h1:mHKLJTE7iXEys6deO5p6olAiZdG5zwp8Aebir+/EaRE=


### PR DESCRIPTION
## Description

Adds decode support to the shared config package so merged configuration values can be copied into caller-provided struct or map targets before runtime-specific setting validation.

## Related Links

- Closes #14
- Refs #12
- Refs #10
- Refs #8
- Refs #6

## Scope

- [x] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [x] Security

## Implementation Notes

- Adds a `Decoder` contract and `MapstructureDecoder` implementation.
- Adds `DecodeValues` and `DecodeMergeResult` helpers for the built-in decode path.
- Decodes merged values into struct pointers and map pointers.
- Enforces `UnknownKeyPolicyAllow` and `UnknownKeyPolicyReject`.
- Uses `github.com/go-viper/mapstructure/v2` internally at `v2.5.0`; mapstructure remains an implementation detail and is not exposed in the public config API.
- Keeps server runtime integration, runtime-specific setting validation, full loader orchestration, and remote configuration providers out of scope.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands and checks:

- `/home/frost/workspace/.tools/go1.25.6/bin/gofmt -w packages/shared/config/decode.go packages/shared/config/decode_test.go packages/shared/config/error.go packages/shared/config/types.go packages/shared/config/validate.go packages/shared/config/doc.go`
- `env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go mod tidy` from `packages/shared`
- `env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go test -count=1 ./packages/shared/... ./server/...`
- `git diff --cached --check`
- `git log --show-signature -1 --format=fuller` verified a good GPG signature for commit `80473d5fefc654672c0ec5570ebe37fe7662e19e`

## Risks

Decode is still generic infrastructure. It intentionally does not validate runtime-specific setting values and does not wire the provider/parser/merge/decode stages into server runtime configuration yet.