### PR TITLE
gh-16 [feat]: Complete shared config loader orchestration

### DIFF
--- a/packages/shared/config/README.md
+++ b/packages/shared/config/README.md
@@ -18,7 +18,7 @@
   @File    : packages/shared/config/README.md
   @Author  : Frost Leo <frostleo.dev@gmail.com>
   @Created : 2026-04-24
-  @Modified: 2026-04-24
+  @Modified: 2026-04-25
 -->
 
 # Shared Config Loader Contract
@@ -43,9 +43,32 @@ The config package does not validate runtime-specific setting values. That belon
 
 ## Current Scope
 
-The current package defines the loader contract, local provider primitives, local parser primitives, parsed source merge primitives, and merged value decode primitives. It includes local file providers, environment variable providers, YAML, JSON, and TOML parsers, Koanf-backed deep replace merge behavior, and mapstructure-backed decode behavior.
+The current package implements the local loader pipeline. It includes local file providers, environment variable providers, YAML, JSON, and TOML parsers, Koanf-backed deep replace merge behavior, mapstructure-backed decode behavior, stable value fingerprints, source diagnostics, and merge override diagnostics.
 
 It does not implement server runtime integration or remote configuration providers.
+
+## Loader Scope
+
+The default loader is responsible for orchestrating one explicit request.
+
+The loader may:
+
+- validate the request contract before reading sources;
+- apply the request timeout to the full load operation;
+- resolve built-in or registered providers and parsers;
+- read every declared source;
+- parse payloads into structured values;
+- merge parsed values by source priority;
+- decode merged values into the caller target;
+- return runtime, environment, ordered source names, diagnostics, and a stable fingerprint.
+
+The loader must not:
+
+- validate runtime-specific setting values;
+- create runtime-specific setting structs;
+- expose Koanf or mapstructure as public API requirements;
+- fetch remote configuration unless a caller registers a provider for that capability;
+- watch files or hot-reload configuration.
 
 ## Provider Scope
 
@@ -119,7 +142,6 @@ The decode layer must not:
 
 - validate runtime-specific setting values;
 - create runtime-specific setting types;
-- orchestrate provider, parser, merge, and decode stages;
 - expose mapstructure as part of the public config package contract.
 
-Server runtime integration and remote configuration providers are separate follow-up milestones.
+Server runtime integration, remote configuration providers, and hot reload behavior are separate follow-up milestones.

--- a/packages/shared/config/doc.go
+++ b/packages/shared/config/doc.go
@@ -18,14 +18,13 @@
  * @File    : doc.go
  * @Author  : Frost Leo <frostleo.dev@gmail.com>
  * @Created : 2026-04-24
- * @Modified: 2026-04-24
+ * @Modified: 2026-04-25
  */
 
 // Package config defines the shared Dox runtime configuration loading contract.
 //
-// The package validates loader API usage, source descriptors, and option
-// consistency. Providers read local payloads, parsers convert local file
-// payloads into structured values, mergers combine parsed source values, and
-// decoders copy merged values into caller-owned targets. Runtime-specific
+// The package validates loader API usage, reads declared local sources, parses
+// source payloads, merges source values by priority, decodes merged values into
+// caller-owned targets, and returns operational diagnostics. Runtime-specific
 // setting validation belongs to each caller.
 package config

--- a/packages/shared/config/loader.go
+++ b/packages/shared/config/loader.go
@@ -18,14 +18,202 @@
  * @File    : loader.go
  * @Author  : Frost Leo <frostleo.dev@gmail.com>
  * @Created : 2026-04-24
- * @Modified: 2026-04-24
+ * @Modified: 2026-04-25
  */
 
 package config
 
-import "context"
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+)
 
-// Loader defines the future configuration loading entrypoint contract.
+// Loader defines the configuration loading entrypoint contract.
 type Loader interface {
 	Load(ctx context.Context, req Request) (*Result, error)
+}
+
+// ProviderFunc adapts a function into a provider implementation.
+type ProviderFunc func(ctx context.Context, source Source) (*Payload, error)
+
+// Read calls f with the provided source.
+func (f ProviderFunc) Read(ctx context.Context, source Source) (*Payload, error) {
+	if f == nil {
+		return nil, ContractError("provider", "provider function must not be nil")
+	}
+	return f(ctx, source)
+}
+
+// LoaderConfig customizes the default loader with additional pipeline components.
+type LoaderConfig struct {
+	Providers map[ProviderKind]Provider
+	Parsers   map[ParserKind]Parser
+	Merger    Merger
+	Decoder   Decoder
+}
+
+// DefaultLoader orchestrates provider, parser, merge, and decode stages.
+type DefaultLoader struct {
+	providers map[ProviderKind]Provider
+	parsers   map[ParserKind]Parser
+	merger    Merger
+	decoder   Decoder
+}
+
+// NewLoader creates a loader with built-in components plus caller overrides.
+func NewLoader(config LoaderConfig) *DefaultLoader {
+	providers := builtinProviders()
+	for kind, provider := range config.Providers {
+		providers[kind] = provider
+	}
+
+	parsers := builtinParsers()
+	for kind, parser := range config.Parsers {
+		parsers[kind] = parser
+	}
+
+	merger := config.Merger
+	if merger == nil {
+		merger = DeepReplaceMerger{}
+	}
+	decoder := config.Decoder
+	if decoder == nil {
+		decoder = MapstructureDecoder{}
+	}
+
+	return &DefaultLoader{
+		providers: providers,
+		parsers:   parsers,
+		merger:    merger,
+		decoder:   decoder,
+	}
+}
+
+// NewDefaultLoader creates a loader with all built-in local components.
+func NewDefaultLoader() *DefaultLoader {
+	return NewLoader(LoaderConfig{})
+}
+
+// Load runs a request through the built-in local loader.
+func Load(ctx context.Context, req Request) (*Result, error) {
+	return NewDefaultLoader().Load(ctx, req)
+}
+
+// Load validates the request, loads sources, merges values, decodes the target, and returns diagnostics.
+func (l *DefaultLoader) Load(ctx context.Context, req Request) (*Result, error) {
+	if l == nil {
+		return nil, ContractError("loader", "loader must not be nil")
+	}
+	if err := ValidateLoadRequest(ctx, req); err != nil {
+		return nil, err
+	}
+	options, err := normalizeOptions(req.Options)
+	if err != nil {
+		return nil, err
+	}
+
+	if options.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, options.Timeout)
+		defer cancel()
+	}
+
+	parsedSources := make([]ParsedSource, 0, len(req.Sources))
+	providers := l.effectiveProviders()
+	parsers := l.effectiveParsers()
+	for index, source := range req.Sources {
+		provider, ok := providers[source.Kind]
+		if !ok || provider == nil {
+			return nil, ContractError(sourceField(index, "kind"), "provider kind is not registered")
+		}
+		payload, err := provider.Read(ctx, source)
+		if err != nil {
+			return nil, err
+		}
+		if payload == nil {
+			return nil, SourceError(sourceField(index, "kind"), "provider returned nil payload", nil)
+		}
+		payload.Source = source
+
+		parser, ok := parsers[source.Parser]
+		if !ok || parser == nil {
+			return nil, ContractError(sourceField(index, "parser"), "parser kind is not registered")
+		}
+		values, err := parser.Parse(ctx, *payload)
+		if err != nil {
+			return nil, err
+		}
+		parsedSources = append(parsedSources, ParsedSourceFromPayload(*payload, values))
+	}
+
+	merger := l.merger
+	if merger == nil {
+		merger = DeepReplaceMerger{}
+	}
+	mergeResult, err := merger.Merge(ctx, parsedSources, options)
+	if err != nil {
+		return nil, err
+	}
+
+	decoder := l.decoder
+	if decoder == nil {
+		decoder = MapstructureDecoder{}
+	}
+	if err := decoder.Decode(ctx, mergeResult.Values, req.Target, options); err != nil {
+		return nil, err
+	}
+
+	fingerprint, err := fingerprintValues(mergeResult.Values)
+	if err != nil {
+		return nil, MergeError("result.values", "fingerprint serialization failed", err)
+	}
+
+	return &Result{
+		Runtime:     req.Runtime,
+		Env:         req.Env,
+		SourceNames: append([]string(nil), mergeResult.SourceNames...),
+		Fingerprint: fingerprint,
+		Diagnostics: mergeResult.Diagnostics,
+	}, nil
+}
+
+func (l *DefaultLoader) effectiveProviders() map[ProviderKind]Provider {
+	if len(l.providers) == 0 {
+		return builtinProviders()
+	}
+	return l.providers
+}
+
+func (l *DefaultLoader) effectiveParsers() map[ParserKind]Parser {
+	if len(l.parsers) == 0 {
+		return builtinParsers()
+	}
+	return l.parsers
+}
+
+func builtinProviders() map[ProviderKind]Provider {
+	return map[ProviderKind]Provider{
+		ProviderKindFile: FileProvider{},
+		ProviderKindEnv:  EnvProvider{},
+	}
+}
+
+func builtinParsers() map[ParserKind]Parser {
+	return map[ParserKind]Parser{
+		ParserKindNone: NoneParser{},
+		ParserKindYAML: YAMLParser{},
+		ParserKindJSON: JSONParser{},
+		ParserKindTOML: TOMLParser{},
+	}
+}
+
+func fingerprintValues(values map[string]any) (string, error) {
+	body, err := json.Marshal(cloneStructuredMap(values))
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(body)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
 }

--- a/packages/shared/config/loader_test.go
+++ b/packages/shared/config/loader_test.go
@@ -1,0 +1,392 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : loader_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-25
+ * @Modified: 2026-04-25
+ */
+
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type loaderSetting struct {
+	App  loaderAppSetting  `mapstructure:"app"`
+	HTTP loaderHTTPSetting `mapstructure:"http"`
+}
+
+type loaderAppSetting struct {
+	Name string `mapstructure:"name"`
+}
+
+type loaderHTTPSetting struct {
+	Port    int           `mapstructure:"port"`
+	Timeout time.Duration `mapstructure:"timeout"`
+}
+
+func TestLoadReadsMergesDecodesAndFingerprints(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.yaml")
+	writeLoaderFixture(t, basePath, `
+app:
+  name: dox
+http:
+  port: 8080
+  timeout: 5s
+`)
+
+	loader := NewLoader(LoaderConfig{
+		Providers: map[ProviderKind]Provider{
+			ProviderKindEnv: EnvProvider{Lookup: func() []string {
+				return []string{
+					"DOX_SERVER_APP_NAME=dox-env",
+					"DOX_SERVER_HTTP_TIMEOUT=10s",
+				}
+			}},
+		},
+	})
+
+	buildRequest := func(target any) Request {
+		return Request{
+			Runtime: "server",
+			Env:     "dev",
+			Target:  target,
+			Sources: []Source{
+				{
+					Name:     "base",
+					Kind:     ProviderKindFile,
+					Parser:   ParserKindYAML,
+					Location: basePath,
+					Required: true,
+					Priority: 10,
+				},
+				{
+					Name:     "env",
+					Kind:     ProviderKindEnv,
+					Parser:   ParserKindNone,
+					Location: "DOX_SERVER_",
+					Priority: 100,
+				},
+			},
+			Options: Options{UnknownKeyPolicy: UnknownKeyPolicyReject},
+		}
+	}
+
+	var target loaderSetting
+	result, err := loader.Load(context.Background(), buildRequest(&target))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	if target.App.Name != "dox-env" {
+		t.Fatalf("expected env override for app.name, got %q", target.App.Name)
+	}
+	if target.HTTP.Port != 8080 {
+		t.Fatalf("expected http.port from file, got %d", target.HTTP.Port)
+	}
+	if target.HTTP.Timeout != 10*time.Second {
+		t.Fatalf("expected env override for http.timeout, got %s", target.HTTP.Timeout)
+	}
+	if result.Runtime != "server" || result.Env != "dev" {
+		t.Fatalf("unexpected result identity: %+v", result)
+	}
+	if !reflect.DeepEqual(result.SourceNames, []string{"base", "env"}) {
+		t.Fatalf("unexpected source names: %+v", result.SourceNames)
+	}
+	if !strings.HasPrefix(result.Fingerprint, "sha256:") {
+		t.Fatalf("expected sha256 fingerprint, got %q", result.Fingerprint)
+	}
+	assertOverride(t, result.Diagnostics.Overrides, "app.name", "env", "base")
+	assertOverride(t, result.Diagnostics.Overrides, "http.timeout", "env", "base")
+
+	var targetAgain loaderSetting
+	resultAgain, err := loader.Load(context.Background(), buildRequest(&targetAgain))
+	if err != nil {
+		t.Fatalf("load config again: %v", err)
+	}
+	if resultAgain.Fingerprint != result.Fingerprint {
+		t.Fatalf("expected stable fingerprint, got %q and %q", result.Fingerprint, resultAgain.Fingerprint)
+	}
+}
+
+func TestLoadKeepsOptionalSourceDiagnostics(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.yaml")
+	writeLoaderFixture(t, basePath, `
+app:
+  name: dox
+`)
+
+	var target loaderSetting
+	result, err := Load(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []Source{
+			{
+				Name:     "base",
+				Kind:     ProviderKindFile,
+				Parser:   ParserKindYAML,
+				Location: basePath,
+				Required: true,
+				Priority: 10,
+			},
+			{
+				Name:     "local",
+				Kind:     ProviderKindFile,
+				Parser:   ParserKindYAML,
+				Location: filepath.Join(dir, "missing.yaml"),
+				Required: false,
+				Priority: 20,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("load config with optional source: %v", err)
+	}
+	if target.App.Name != "dox" {
+		t.Fatalf("expected base app.name, got %q", target.App.Name)
+	}
+	diagnostic := findSourceDiagnostic(result.Diagnostics.Sources, "local")
+	if diagnostic == nil || !diagnostic.Skipped || diagnostic.Loaded {
+		t.Fatalf("expected skipped optional diagnostic, got %+v", diagnostic)
+	}
+}
+
+func TestLoadAllowsEmptySourcesWhenExplicit(t *testing.T) {
+	var target map[string]any
+	result, err := Load(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Options: Options{AllowEmptySources: true},
+	})
+	if err != nil {
+		t.Fatalf("load empty sources: %v", err)
+	}
+	if len(target) != 0 {
+		t.Fatalf("expected empty target map, got %+v", target)
+	}
+	if len(result.SourceNames) != 0 {
+		t.Fatalf("expected no source names, got %+v", result.SourceNames)
+	}
+	if !strings.HasPrefix(result.Fingerprint, "sha256:") {
+		t.Fatalf("expected sha256 fingerprint, got %q", result.Fingerprint)
+	}
+}
+
+func TestLoadReturnsParseError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "base.yaml")
+	writeLoaderFixture(t, path, "app: [")
+
+	var target map[string]any
+	_, err := Load(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []Source{{
+			Name:     "base",
+			Kind:     ProviderKindFile,
+			Parser:   ParserKindYAML,
+			Location: path,
+			Required: true,
+		}},
+	})
+
+	if !IsKind(err, ErrorKindParse) {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+}
+
+func TestLoadReturnsDecodeError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "base.yaml")
+	writeLoaderFixture(t, path, `
+app:
+  name: dox
+  extra: true
+`)
+
+	var target loaderSetting
+	_, err := Load(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []Source{{
+			Name:     "base",
+			Kind:     ProviderKindFile,
+			Parser:   ParserKindYAML,
+			Location: path,
+			Required: true,
+		}},
+	})
+
+	if !IsKind(err, ErrorKindDecode) {
+		t.Fatalf("expected decode error, got %v", err)
+	}
+}
+
+func TestLoadRejectsUnsupportedProviderKind(t *testing.T) {
+	var target map[string]any
+	_, err := Load(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []Source{{
+			Name:     "memory",
+			Kind:     ProviderKind("memory"),
+			Parser:   ParserKindNone,
+			Location: "memory",
+			Required: true,
+		}},
+	})
+
+	if !IsKind(err, ErrorKindContract) {
+		t.Fatalf("expected contract error, got %v", err)
+	}
+}
+
+func TestLoadRejectsUnsupportedParserKind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "base.jsonnet")
+	writeLoaderFixture(t, path, "{}")
+
+	var target map[string]any
+	_, err := Load(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []Source{{
+			Name:     "base",
+			Kind:     ProviderKindFile,
+			Parser:   ParserKind("jsonnet"),
+			Location: path,
+			Required: true,
+		}},
+	})
+
+	if !IsKind(err, ErrorKindContract) {
+		t.Fatalf("expected contract error, got %v", err)
+	}
+}
+
+func TestLoadUsesCustomProviderAndParser(t *testing.T) {
+	customProvider := ProviderKind("memory")
+	customParser := ParserKind("passthrough")
+	loader := NewLoader(LoaderConfig{
+		Providers: map[ProviderKind]Provider{
+			customProvider: ProviderFunc(func(ctx context.Context, source Source) (*Payload, error) {
+				return &Payload{
+					Source: source,
+					Values: map[string]any{
+						"app": map[string]any{"name": "custom"},
+					},
+					Diagnostic: SourceDiagnostic{
+						Name:   source.Name,
+						Kind:   source.Kind,
+						Loaded: true,
+					},
+				}, nil
+			}),
+		},
+		Parsers: map[ParserKind]Parser{
+			customParser: ParserFunc(func(ctx context.Context, payload Payload) (map[string]any, error) {
+				return cloneStructuredMap(payload.Values), nil
+			}),
+		},
+	})
+
+	var target loaderSetting
+	result, err := loader.Load(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []Source{{
+			Name:     "memory",
+			Kind:     customProvider,
+			Parser:   customParser,
+			Location: "memory",
+			Required: true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("load custom source: %v", err)
+	}
+	if target.App.Name != "custom" {
+		t.Fatalf("expected custom app.name, got %q", target.App.Name)
+	}
+	if !reflect.DeepEqual(result.SourceNames, []string{"memory"}) {
+		t.Fatalf("unexpected source names: %+v", result.SourceNames)
+	}
+}
+
+func TestLoadHonorsTimeout(t *testing.T) {
+	slowProvider := ProviderKind("slow")
+	loader := NewLoader(LoaderConfig{
+		Providers: map[ProviderKind]Provider{
+			slowProvider: ProviderFunc(func(ctx context.Context, source Source) (*Payload, error) {
+				<-ctx.Done()
+				return nil, SourceError("ctx", "context is done", ctx.Err())
+			}),
+		},
+	})
+
+	var target map[string]any
+	_, err := loader.Load(context.Background(), Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []Source{{
+			Name:     "slow",
+			Kind:     slowProvider,
+			Parser:   ParserKindNone,
+			Location: "memory",
+			Required: true,
+		}},
+		Options: Options{Timeout: time.Nanosecond},
+	})
+
+	if !IsKind(err, ErrorKindSource) {
+		t.Fatalf("expected source timeout error, got %v", err)
+	}
+}
+
+func writeLoaderFixture(t *testing.T, path string, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}
+
+func findSourceDiagnostic(diagnostics []SourceDiagnostic, name string) *SourceDiagnostic {
+	for index := range diagnostics {
+		if diagnostics[index].Name == name {
+			return &diagnostics[index]
+		}
+	}
+	return nil
+}

--- a/packages/shared/config/types.go
+++ b/packages/shared/config/types.go
@@ -18,7 +18,7 @@
  * @File    : types.go
  * @Author  : Frost Leo <frostleo.dev@gmail.com>
  * @Created : 2026-04-24
- * @Modified: 2026-04-24
+ * @Modified: 2026-04-25
  */
 
 package config
@@ -62,7 +62,7 @@ const (
 	MergeStrategyDeepReplace MergeStrategy = "deep_replace"
 )
 
-// UnknownKeyPolicy defines how the future decoder should handle unknown fields.
+// UnknownKeyPolicy defines how the decoder should handle unknown fields.
 type UnknownKeyPolicy string
 
 const (
@@ -135,7 +135,7 @@ type Request struct {
 	Options Options
 }
 
-// Options controls future loading, merge, decode, and diagnostics behavior.
+// Options controls loading, merge, decode, and diagnostics behavior.
 type Options struct {
 	AllowEmptySources bool
 	MergeStrategy     MergeStrategy
@@ -144,7 +144,7 @@ type Options struct {
 	RedactKeys        []string
 }
 
-// Result describes the future output shape of a completed load.
+// Result describes the output shape of a completed load.
 type Result struct {
 	Runtime     string
 	Env         string
@@ -153,7 +153,7 @@ type Result struct {
 	Diagnostics Diagnostics
 }
 
-// Diagnostics records future source and merge metadata for operational review.
+// Diagnostics records source and merge metadata for operational review.
 type Diagnostics struct {
 	Sources   []SourceDiagnostic
 	Overrides []MergeOverride


### PR DESCRIPTION
## Description

Completes the packages/shared/config local loader pipeline. The package now has a concrete default loader that validates explicit requests, reads declared sources, parses payloads, merges values, decodes into caller-owned targets, and returns source diagnostics plus a stable fingerprint.

## Related Links

- Closes #16
- Refs #6
- Refs #8
- Refs #10
- Refs #12
- Refs #14

## Scope

- [ ] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [ ] Security

## Implementation Notes

- Adds DefaultLoader, NewLoader, NewDefaultLoader, and package-level Load for the completed local pipeline.
- Adds provider and parser registry extension points so future providers can plug in without exposing Koanf or mapstructure in the public API.
- Adds stable sha256 fingerprints from merged values while keeping raw configuration values out of Result diagnostics.
- Keeps server setting definitions, runtime value validation, remote providers, and hot reload out of scope.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands:

- `env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go test -count=1 ./packages/shared/... ./server/...`
- `git diff --check`

## Risks

Runtime-specific setting validation still belongs in each runtime integration package. Remote configuration providers and hot reload are intentionally deferred follow-up work.