### PR TITLE
gh-18 [feat]: Add server bootstrap config snapshot loading

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -18,14 +18,27 @@
   @File    : server/README.md
   @Author  : Frost Leo <frostleo.dev@gmail.com>
   @Created : 2026-04-24
-  @Modified: 2026-04-24
+  @Modified: 2026-04-25
 -->
 
 # Dox Server
 
 `server` is the Web backend runtime for Dox.
 
-The current module only contains the CLI entrypoint and shared version command. HTTP server startup, configuration, logging, database access, and EDA integration are intentionally out of scope for this milestone.
+The current module contains the CLI entrypoint, shared version command, and bootstrap configuration snapshot loading. HTTP server startup, concrete runtime setting definitions, logging, database access, and EDA integration are intentionally out of scope for this milestone.
+
+## Configuration Bootstrap
+
+`server/internal/bootstrap` can load a startup configuration snapshot through `packages/shared/config`.
+
+The current bootstrap convention is:
+
+- `configs/base.<format>` as the required baseline source;
+- `configs/<env>.<format>` as an optional environment override;
+- `configs/local.<format>` as an optional local override;
+- `DOX_SERVER_` environment variables as optional final overrides.
+
+The bootstrap snapshot currently uses `map[string]any`. Concrete HTTP, database, cache, logger, security, and IAM setting structs remain out of scope until those runtime resources are introduced.
 
 ## Usage
 

--- a/server/internal/bootstrap/config.go
+++ b/server/internal/bootstrap/config.go
@@ -1,0 +1,220 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : config.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-25
+ * @Modified: 2026-04-25
+ */
+
+package bootstrap
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"time"
+
+	sharedconfig "github.com/opendox/dox/packages/shared/config"
+)
+
+const (
+	// DefaultConfigDir is the default directory for server configuration files.
+	DefaultConfigDir = "configs"
+	// DefaultConfigEnv is the default server runtime environment name.
+	DefaultConfigEnv = "dev"
+	// DefaultConfigFormat is the default server configuration file format.
+	DefaultConfigFormat = "yaml"
+	// DefaultConfigEnvPrefix is the default prefix for server configuration value overrides.
+	DefaultConfigEnvPrefix = "DOX_SERVER_"
+
+	configRuntime = "server"
+)
+
+const (
+	configBasePriority        = 10
+	configEnvironmentPriority = 20
+	configLocalPriority       = 30
+	configEnvPriority         = 100
+)
+
+// ConfigOptions defines startup inputs for server configuration loading.
+type ConfigOptions struct {
+	ConfigDir string
+	Env       string
+	Format    string
+	EnvPrefix string
+	Timeout   time.Duration
+}
+
+// ConfigSnapshot captures the merged server configuration values loaded during bootstrap.
+type ConfigSnapshot struct {
+	Runtime     string
+	Env         string
+	Values      map[string]any
+	SourceNames []string
+	Fingerprint string
+	Diagnostics sharedconfig.Diagnostics
+}
+
+// LoadConfig loads the server startup configuration snapshot.
+//
+// Source order is:
+//   - configs/base.<format>, required baseline
+//   - configs/<env>.<format>, optional environment override
+//   - configs/local.<format>, optional local override
+//   - environment variables with EnvPrefix, optional final override
+//
+// The snapshot intentionally uses a generic map target. Concrete resource
+// settings belong to later server-owned setting packages.
+func LoadConfig(ctx context.Context, options ConfigOptions) (*ConfigSnapshot, error) {
+	normalized, err := normalizeConfigOptions(options)
+	if err != nil {
+		return nil, err
+	}
+
+	values := map[string]any{}
+	result, err := sharedconfig.Load(ctx, sharedconfig.Request{
+		Runtime: configRuntime,
+		Env:     normalized.Env,
+		Target:  &values,
+		Sources: buildConfigSources(normalized),
+		Options: sharedconfig.Options{
+			Timeout:          normalized.Timeout,
+			UnknownKeyPolicy: sharedconfig.UnknownKeyPolicyAllow,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &ConfigSnapshot{
+		Runtime:     result.Runtime,
+		Env:         result.Env,
+		Values:      cloneConfigValues(values),
+		SourceNames: append([]string(nil), result.SourceNames...),
+		Fingerprint: result.Fingerprint,
+		Diagnostics: result.Diagnostics,
+	}, nil
+}
+
+func normalizeConfigOptions(options ConfigOptions) (ConfigOptions, error) {
+	options.ConfigDir = strings.TrimSpace(options.ConfigDir)
+	if options.ConfigDir == "" {
+		options.ConfigDir = DefaultConfigDir
+	}
+
+	options.Env = strings.TrimSpace(options.Env)
+	if options.Env == "" {
+		options.Env = DefaultConfigEnv
+	}
+
+	format := strings.TrimSpace(options.Format)
+	format = strings.TrimPrefix(format, ".")
+	format = strings.ToLower(format)
+	if format == "" {
+		format = DefaultConfigFormat
+	}
+	if _, err := parserForFormat(format); err != nil {
+		return options, err
+	}
+	options.Format = format
+
+	options.EnvPrefix = strings.TrimSpace(options.EnvPrefix)
+	if options.EnvPrefix == "" {
+		options.EnvPrefix = DefaultConfigEnvPrefix
+	}
+
+	return options, nil
+}
+
+func buildConfigSources(options ConfigOptions) []sharedconfig.Source {
+	parser, _ := parserForFormat(options.Format)
+	return []sharedconfig.Source{
+		{
+			Name:     "base",
+			Kind:     sharedconfig.ProviderKindFile,
+			Parser:   parser,
+			Location: filepath.Join(options.ConfigDir, "base."+options.Format),
+			Required: true,
+			Priority: configBasePriority,
+		},
+		{
+			Name:     "environment",
+			Kind:     sharedconfig.ProviderKindFile,
+			Parser:   parser,
+			Location: filepath.Join(options.ConfigDir, options.Env+"."+options.Format),
+			Required: false,
+			Priority: configEnvironmentPriority,
+		},
+		{
+			Name:     "local",
+			Kind:     sharedconfig.ProviderKindFile,
+			Parser:   parser,
+			Location: filepath.Join(options.ConfigDir, "local."+options.Format),
+			Required: false,
+			Priority: configLocalPriority,
+		},
+		{
+			Name:     "env",
+			Kind:     sharedconfig.ProviderKindEnv,
+			Parser:   sharedconfig.ParserKindNone,
+			Location: options.EnvPrefix,
+			Required: false,
+			Priority: configEnvPriority,
+		},
+	}
+}
+
+func parserForFormat(format string) (sharedconfig.ParserKind, error) {
+	switch format {
+	case "yaml", "yml":
+		return sharedconfig.ParserKindYAML, nil
+	case "json":
+		return sharedconfig.ParserKindJSON, nil
+	case "toml":
+		return sharedconfig.ParserKindTOML, nil
+	default:
+		return "", sharedconfig.ContractError("options.format", "config format is not supported")
+	}
+}
+
+func cloneConfigValues(input map[string]any) map[string]any {
+	if len(input) == 0 {
+		return map[string]any{}
+	}
+	values := make(map[string]any, len(input))
+	for key, value := range input {
+		values[key] = cloneConfigValue(value)
+	}
+	return values
+}
+
+func cloneConfigValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneConfigValues(typed)
+	case []any:
+		values := make([]any, len(typed))
+		for index, entry := range typed {
+			values[index] = cloneConfigValue(entry)
+		}
+		return values
+	default:
+		return value
+	}
+}

--- a/server/internal/bootstrap/config_test.go
+++ b/server/internal/bootstrap/config_test.go
@@ -1,0 +1,242 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : config_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-25
+ * @Modified: 2026-04-25
+ */
+
+package bootstrap
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	sharedconfig "github.com/opendox/dox/packages/shared/config"
+)
+
+func TestBuildConfigSourcesUsesDefaultConvention(t *testing.T) {
+	options, err := normalizeConfigOptions(ConfigOptions{})
+	if err != nil {
+		t.Fatalf("normalize default options: %v", err)
+	}
+
+	sources := buildConfigSources(options)
+	if len(sources) != 4 {
+		t.Fatalf("expected four config sources, got %+v", sources)
+	}
+
+	expected := []sharedconfig.Source{
+		{
+			Name:     "base",
+			Kind:     sharedconfig.ProviderKindFile,
+			Parser:   sharedconfig.ParserKindYAML,
+			Location: filepath.Join("configs", "base.yaml"),
+			Required: true,
+			Priority: 10,
+		},
+		{
+			Name:     "environment",
+			Kind:     sharedconfig.ProviderKindFile,
+			Parser:   sharedconfig.ParserKindYAML,
+			Location: filepath.Join("configs", "dev.yaml"),
+			Required: false,
+			Priority: 20,
+		},
+		{
+			Name:     "local",
+			Kind:     sharedconfig.ProviderKindFile,
+			Parser:   sharedconfig.ParserKindYAML,
+			Location: filepath.Join("configs", "local.yaml"),
+			Required: false,
+			Priority: 30,
+		},
+		{
+			Name:     "env",
+			Kind:     sharedconfig.ProviderKindEnv,
+			Parser:   sharedconfig.ParserKindNone,
+			Location: "DOX_SERVER_",
+			Required: false,
+			Priority: 100,
+		},
+	}
+	if !reflect.DeepEqual(sources, expected) {
+		t.Fatalf("unexpected default sources:\nwant: %+v\n got: %+v", expected, sources)
+	}
+}
+
+func TestLoadConfigBuildsSnapshotAndAppliesOverrides(t *testing.T) {
+	dir := t.TempDir()
+	writeBootstrapFixture(t, filepath.Join(dir, "base.yaml"), `
+app:
+  name: base
+http:
+  timeout: 5s
+`)
+	writeBootstrapFixture(t, filepath.Join(dir, "dev.yaml"), `
+app:
+  environment: dev
+http:
+  timeout: 10s
+`)
+
+	prefix := "DOX_BOOTSTRAP_TEST_SNAPSHOT_"
+	t.Setenv(prefix+"APP_NAME", "env")
+	t.Setenv("DOX_ENV", "prod")
+	t.Setenv("DOX_CONFIG_DIR", "/tmp/not-used")
+	t.Setenv("DOX_CONFIG_FORMAT", "json")
+
+	snapshot, err := LoadConfig(context.Background(), ConfigOptions{
+		ConfigDir: dir,
+		Env:       "dev",
+		Format:    "yaml",
+		EnvPrefix: prefix,
+	})
+	if err != nil {
+		t.Fatalf("load config snapshot: %v", err)
+	}
+
+	if snapshot.Runtime != "server" || snapshot.Env != "dev" {
+		t.Fatalf("unexpected snapshot identity: %+v", snapshot)
+	}
+	if !reflect.DeepEqual(snapshot.SourceNames, []string{"base", "environment", "local", "env"}) {
+		t.Fatalf("unexpected source names: %+v", snapshot.SourceNames)
+	}
+	if !strings.HasPrefix(snapshot.Fingerprint, "sha256:") {
+		t.Fatalf("expected sha256 fingerprint, got %q", snapshot.Fingerprint)
+	}
+
+	app := assertBootstrapMap(t, snapshot.Values["app"])
+	if got := app["name"]; got != "env" {
+		t.Fatalf("expected app.name from env override, got %v", got)
+	}
+	if got := app["environment"]; got != "dev" {
+		t.Fatalf("expected app.environment from environment file, got %v", got)
+	}
+	http := assertBootstrapMap(t, snapshot.Values["http"])
+	if got := http["timeout"]; got != "10s" {
+		t.Fatalf("expected http.timeout from environment file, got %v", got)
+	}
+	if _, exists := snapshot.Values["env"]; exists {
+		t.Fatalf("did not expect bootstrap control DOX_ENV in config values: %+v", snapshot.Values)
+	}
+	if _, exists := snapshot.Values["config"]; exists {
+		t.Fatalf("did not expect bootstrap control DOX_CONFIG_* in config values: %+v", snapshot.Values)
+	}
+
+	localDiagnostic := findBootstrapDiagnostic(snapshot.Diagnostics.Sources, "local")
+	if localDiagnostic == nil || !localDiagnostic.Skipped || localDiagnostic.Loaded {
+		t.Fatalf("expected skipped local diagnostic, got %+v", localDiagnostic)
+	}
+	assertBootstrapOverride(t, snapshot.Diagnostics.Overrides, "app.name", "env", "base")
+	assertBootstrapOverride(t, snapshot.Diagnostics.Overrides, "http.timeout", "environment", "base")
+}
+
+func TestLoadConfigSkipsMissingOptionalSources(t *testing.T) {
+	dir := t.TempDir()
+	writeBootstrapFixture(t, filepath.Join(dir, "base.yaml"), `
+app:
+  name: base
+`)
+
+	snapshot, err := LoadConfig(context.Background(), ConfigOptions{
+		ConfigDir: dir,
+		Env:       "dev",
+		Format:    "yaml",
+		EnvPrefix: "DOX_BOOTSTRAP_TEST_EMPTY_18_",
+	})
+	if err != nil {
+		t.Fatalf("load config snapshot: %v", err)
+	}
+
+	app := assertBootstrapMap(t, snapshot.Values["app"])
+	if got := app["name"]; got != "base" {
+		t.Fatalf("expected app.name from base file, got %v", got)
+	}
+	for _, name := range []string{"environment", "local", "env"} {
+		diagnostic := findBootstrapDiagnostic(snapshot.Diagnostics.Sources, name)
+		if diagnostic == nil || !diagnostic.Skipped || diagnostic.Loaded {
+			t.Fatalf("expected skipped diagnostic for %s, got %+v", name, diagnostic)
+		}
+	}
+}
+
+func TestLoadConfigReturnsSourceErrorWhenBaseMissing(t *testing.T) {
+	_, err := LoadConfig(context.Background(), ConfigOptions{
+		ConfigDir: t.TempDir(),
+		Env:       "dev",
+		Format:    "yaml",
+		EnvPrefix: "DOX_BOOTSTRAP_TEST_MISSING_BASE_",
+	})
+
+	if !sharedconfig.IsKind(err, sharedconfig.ErrorKindSource) {
+		t.Fatalf("expected source error, got %v", err)
+	}
+}
+
+func TestLoadConfigRejectsUnsupportedFormat(t *testing.T) {
+	_, err := LoadConfig(context.Background(), ConfigOptions{
+		ConfigDir: t.TempDir(),
+		Env:       "dev",
+		Format:    "ini",
+		EnvPrefix: "DOX_BOOTSTRAP_TEST_FORMAT_",
+	})
+
+	if !sharedconfig.IsKind(err, sharedconfig.ErrorKindContract) {
+		t.Fatalf("expected contract error, got %v", err)
+	}
+}
+
+func writeBootstrapFixture(t *testing.T, path string, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(body, "\n")), 0o600); err != nil {
+		t.Fatalf("write fixture %s: %v", path, err)
+	}
+}
+
+func assertBootstrapMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+	values, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map value, got %T: %v", value, value)
+	}
+	return values
+}
+
+func findBootstrapDiagnostic(diagnostics []sharedconfig.SourceDiagnostic, name string) *sharedconfig.SourceDiagnostic {
+	for index := range diagnostics {
+		if diagnostics[index].Name == name {
+			return &diagnostics[index]
+		}
+	}
+	return nil
+}
+
+func assertBootstrapOverride(t *testing.T, overrides []sharedconfig.MergeOverride, path string, source string, previous string) {
+	t.Helper()
+	for _, override := range overrides {
+		if override.Path == path && override.Source == source && override.PreviousSource == previous {
+			return
+		}
+	}
+	t.Fatalf("expected override path=%s source=%s previous=%s in %+v", path, source, previous, overrides)
+}


### PR DESCRIPTION
## Description

Add a server bootstrap configuration snapshot loader that uses `packages/shared/config` to assemble startup config sources and return merged map values, diagnostics, and fingerprints.

## Related Links

- Closes #18
- Refs #4
- Refs #16

## Scope

- [x] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [ ] Security

## Implementation Notes

- Added `server/internal/bootstrap` as the startup boundary for config snapshot loading.
- Kept the snapshot target as `map[string]any` so concrete resource settings can be introduced progressively later.
- Built the source convention as required base file, optional environment file, optional local file, and optional `DOX_SERVER_` environment overrides.
- Kept CLI flags, HTTP startup, runtime setting structs, hot reload, and remote providers out of scope.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands:

```bash
env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go test -count=1 ./packages/shared/... ./server/...
```

## Risks

- This PR establishes the bootstrap source convention only. Concrete setting structs and runtime validation remain follow-up work when server resources are introduced.
- Raw config values are not exposed through CLI output in this change.