### PR TITLE
gh-22 [feat]: Refine shared identity setting model

### DIFF
--- a/packages/shared/setting/application.go
+++ b/packages/shared/setting/application.go
@@ -18,7 +18,7 @@
  * @File    : application.go
  * @Author  : Frost Leo <frostleo.dev@gmail.com>
  * @Created : 2026-04-25
- * @Modified: 2026-04-25
+ * @Modified: 2026-04-26
  */
 
 package setting
@@ -26,10 +26,10 @@ package setting
 import "errors"
 
 const (
-	// DefaultApplicationName is the shared Dox application family name.
+	// DefaultOrganizationName is the default Dox organization identity.
+	DefaultOrganizationName = "opendox"
+	// DefaultApplicationName is the shared Dox product or application family name.
 	DefaultApplicationName = "dox"
-	// DefaultApplicationNamespace is the shared Dox service namespace.
-	DefaultApplicationNamespace = "opendox"
 )
 
 // Runtime identifies one Dox runtime system.
@@ -80,16 +80,36 @@ func (e Env) IsValid() bool {
 	}
 }
 
-// Application describes the shared identity of a Dox runtime process.
-type Application struct {
-	Name      string  `json:"name" yaml:"name" mapstructure:"name" validate:"required,dox_kebab"`
-	Namespace string  `json:"namespace" yaml:"namespace" mapstructure:"namespace" validate:"required,dox_kebab"`
-	Runtime   Runtime `json:"runtime" yaml:"runtime" mapstructure:"runtime" validate:"required,dox_runtime"`
-	Service   string  `json:"service" yaml:"service" mapstructure:"service" validate:"required,dox_kebab"`
-	Env       Env     `json:"env" yaml:"env" mapstructure:"env" validate:"required,dox_env"`
+// Organization describes shared ownership and governance identity.
+type Organization struct {
+	Name       string `json:"name" yaml:"name" mapstructure:"name" validate:"required,dox_identifier"`
+	Owner      string `json:"owner" yaml:"owner" mapstructure:"owner" validate:"omitempty,dox_identifier"`
+	CostCenter string `json:"cost_center" yaml:"cost_center" mapstructure:"cost_center" validate:"omitempty,dox_identifier"`
+	Project    string `json:"project" yaml:"project" mapstructure:"project" validate:"omitempty,dox_identifier"`
 }
 
-// Default fills stable shared application identity defaults.
+// Default fills stable shared organization defaults.
+func (o *Organization) Default() error {
+	if o == nil {
+		return errors.New("setting: organization must not be nil")
+	}
+	if o.Name == "" {
+		o.Name = DefaultOrganizationName
+	}
+	return nil
+}
+
+// Validate verifies that organization identity fields use stable syntax.
+func (o Organization) Validate() error {
+	return Validate(o)
+}
+
+// Application describes the product or application family identity.
+type Application struct {
+	Name string `json:"name" yaml:"name" mapstructure:"name" validate:"required,dox_kebab"`
+}
+
+// Default fills stable shared application defaults.
 func (a *Application) Default() error {
 	if a == nil {
 		return errors.New("setting: application must not be nil")
@@ -97,19 +117,54 @@ func (a *Application) Default() error {
 	if a.Name == "" {
 		a.Name = DefaultApplicationName
 	}
-	if a.Namespace == "" {
-		a.Namespace = DefaultApplicationNamespace
-	}
-	if a.Env == "" {
-		a.Env = EnvDev
-	}
-	if a.Service == "" && a.Name != "" && a.Runtime != "" {
-		a.Service = a.Name + "-" + string(a.Runtime)
+	return nil
+}
+
+// Validate verifies that application identity fields use stable syntax.
+func (a Application) Validate() error {
+	return Validate(a)
+}
+
+// System describes the Dox core system identity for a runtime.
+type System struct {
+	Runtime Runtime `json:"runtime" yaml:"runtime" mapstructure:"runtime" validate:"required,dox_runtime"`
+}
+
+// Default is currently a no-op because Dox runtime identity must be explicit.
+func (s *System) Default() error {
+	if s == nil {
+		return errors.New("setting: system must not be nil")
 	}
 	return nil
 }
 
-// Validate verifies that application identity fields use supported Dox values.
-func (a Application) Validate() error {
-	return Validate(a)
+// Validate verifies that system identity fields use supported Dox values.
+func (s System) Validate() error {
+	return Validate(s)
+}
+
+// Service describes one logical service identity.
+type Service struct {
+	Namespace  string `json:"namespace" yaml:"namespace" mapstructure:"namespace" validate:"required,dox_kebab"`
+	Name       string `json:"name" yaml:"name" mapstructure:"name" validate:"required,dox_kebab"`
+	InstanceID string `json:"instance_id" yaml:"instance_id" mapstructure:"instance_id" validate:"omitempty,dox_identifier"`
+}
+
+// Default fills service identity defaults from the application and system identity.
+func (s *Service) Default(application Application, system System) error {
+	if s == nil {
+		return errors.New("setting: service must not be nil")
+	}
+	if s.Namespace == "" {
+		s.Namespace = application.Name
+	}
+	if s.Name == "" && system.Runtime != "" {
+		s.Name = string(system.Runtime)
+	}
+	return nil
+}
+
+// Validate verifies that service identity fields use stable syntax.
+func (s Service) Validate() error {
+	return Validate(s)
 }

--- a/packages/shared/setting/application_test.go
+++ b/packages/shared/setting/application_test.go
@@ -18,7 +18,7 @@
  * @File    : application_test.go
  * @Author  : Frost Leo <frostleo.dev@gmail.com>
  * @Created : 2026-04-25
- * @Modified: 2026-04-25
+ * @Modified: 2026-04-26
  */
 
 package setting
@@ -28,103 +28,183 @@ import (
 	"testing"
 )
 
-func TestApplicationDefaultDerivesSharedIdentity(t *testing.T) {
-	app := Application{Runtime: RuntimeServer}
+func TestIdentityFragmentsApplyConservativeDefaults(t *testing.T) {
+	organization := Organization{}
+	application := Application{}
+	system := System{Runtime: RuntimeServer}
+	service := Service{}
+	deployment := Deployment{}
 
-	if err := app.Default(); err != nil {
-		t.Fatalf("default application: %v", err)
+	for _, item := range []struct {
+		name      string
+		defaulter func() error
+	}{
+		{"organization", organization.Default},
+		{"application", application.Default},
+		{"system", system.Default},
+		{"service", func() error {
+			return service.Default(application, system)
+		}},
+		{"deployment", deployment.Default},
+	} {
+		if err := item.defaulter(); err != nil {
+			t.Fatalf("default %s: %v", item.name, err)
+		}
 	}
 
-	if app.Name != "dox" {
-		t.Fatalf("expected default name dox, got %q", app.Name)
+	if organization.Name != "opendox" {
+		t.Fatalf("expected organization default opendox, got %q", organization.Name)
 	}
-	if app.Namespace != "opendox" {
-		t.Fatalf("expected default namespace opendox, got %q", app.Namespace)
+	if application.Name != "dox" {
+		t.Fatalf("expected application default dox, got %q", application.Name)
 	}
-	if app.Env != EnvDev {
-		t.Fatalf("expected default env dev, got %q", app.Env)
+	if system.Runtime != RuntimeServer {
+		t.Fatalf("expected explicit runtime to remain server, got %q", system.Runtime)
 	}
-	if app.Runtime != RuntimeServer {
-		t.Fatalf("expected runtime to remain server, got %q", app.Runtime)
+	if service.Namespace != "dox" {
+		t.Fatalf("expected service namespace from application name, got %q", service.Namespace)
 	}
-	if app.Service != "dox-server" {
-		t.Fatalf("expected derived service dox-server, got %q", app.Service)
+	if service.Name != "server" {
+		t.Fatalf("expected service name from system runtime, got %q", service.Name)
 	}
-	if err := app.Validate(); err != nil {
-		t.Fatalf("validate defaulted application: %v", err)
+	if deployment.Env != EnvDev {
+		t.Fatalf("expected deployment env default dev, got %q", deployment.Env)
+	}
+
+	for name, validator := range map[string]func() error{
+		"organization": organization.Validate,
+		"application":  application.Validate,
+		"system":       system.Validate,
+		"service":      service.Validate,
+		"deployment":   deployment.Validate,
+	} {
+		if err := validator(); err != nil {
+			t.Fatalf("validate %s: %v", name, err)
+		}
 	}
 }
 
-func TestApplicationDefaultDoesNotInventRuntime(t *testing.T) {
-	app := Application{}
+func TestSystemDefaultDoesNotInventRuntime(t *testing.T) {
+	system := System{}
 
-	if err := app.Default(); err != nil {
-		t.Fatalf("default application: %v", err)
+	if err := system.Default(); err != nil {
+		t.Fatalf("default system: %v", err)
 	}
-	if app.Runtime != "" {
-		t.Fatalf("expected runtime to remain empty, got %q", app.Runtime)
+	if system.Runtime != "" {
+		t.Fatalf("expected runtime to remain empty, got %q", system.Runtime)
 	}
-	if app.Service != "" {
-		t.Fatalf("expected service to remain empty without runtime, got %q", app.Service)
-	}
-	if err := app.Validate(); !hasValidationField(err, "Application.runtime", "required") {
+	if err := system.Validate(); !hasValidationField(err, "System.runtime", "required") {
 		t.Fatalf("expected required runtime validation error, got %v", err)
 	}
 }
 
-func TestApplicationDefaultPreservesExplicitService(t *testing.T) {
-	app := Application{
-		Name:      "dox",
-		Namespace: "opendox",
-		Runtime:   RuntimeCollector,
-		Service:   "amazon-collector",
-		Env:       EnvProd,
-	}
-
-	if err := app.Default(); err != nil {
+func TestServiceDefaultDoesNotInventNameWithoutRuntime(t *testing.T) {
+	application := Application{}
+	if err := application.Default(); err != nil {
 		t.Fatalf("default application: %v", err)
 	}
-	if app.Service != "amazon-collector" {
-		t.Fatalf("expected explicit service to remain, got %q", app.Service)
+
+	service := Service{}
+	if err := service.Default(application, System{}); err != nil {
+		t.Fatalf("default service: %v", err)
 	}
-	if err := app.Validate(); err != nil {
-		t.Fatalf("validate application: %v", err)
+	if service.Namespace != "dox" {
+		t.Fatalf("expected service namespace from application name, got %q", service.Namespace)
+	}
+	if service.Name != "" {
+		t.Fatalf("expected service name to remain empty without runtime, got %q", service.Name)
+	}
+	if err := service.Validate(); !hasValidationField(err, "Service.name", "required") {
+		t.Fatalf("expected required service name validation error, got %v", err)
 	}
 }
 
-func TestApplicationValidateRejectsInvalidRuntime(t *testing.T) {
-	app := validApplication()
-	app.Runtime = Runtime("worker")
+func TestServiceDefaultPreservesExplicitName(t *testing.T) {
+	application := Application{Name: "dox"}
+	system := System{Runtime: RuntimeServer}
+	service := Service{Name: "iam"}
 
-	if err := app.Validate(); !hasValidationField(err, "Application.runtime", "dox_runtime") {
+	if err := service.Default(application, system); err != nil {
+		t.Fatalf("default service: %v", err)
+	}
+	if service.Namespace != "dox" {
+		t.Fatalf("expected service namespace from application name, got %q", service.Namespace)
+	}
+	if service.Name != "iam" {
+		t.Fatalf("expected explicit service name to remain, got %q", service.Name)
+	}
+	if err := service.Validate(); err != nil {
+		t.Fatalf("validate service: %v", err)
+	}
+}
+
+func TestSystemValidateRejectsInvalidRuntime(t *testing.T) {
+	system := System{Runtime: Runtime("worker")}
+
+	if err := system.Validate(); !hasValidationField(err, "System.runtime", "dox_runtime") {
 		t.Fatalf("expected invalid runtime validation error, got %v", err)
 	}
 }
 
-func TestApplicationValidateRejectsInvalidEnv(t *testing.T) {
-	app := validApplication()
-	app.Env = Env("production")
+func TestDeploymentValidateRejectsInvalidEnv(t *testing.T) {
+	deployment := Deployment{Env: Env("production")}
 
-	if err := app.Validate(); !hasValidationField(err, "Application.env", "dox_env") {
+	if err := deployment.Validate(); !hasValidationField(err, "Deployment.env", "dox_env") {
 		t.Fatalf("expected invalid env validation error, got %v", err)
 	}
 }
 
-func TestApplicationValidateRejectsInvalidIdentifierSyntax(t *testing.T) {
-	app := validApplication()
-	app.Service = "Dox Server"
+func TestServiceValidateRejectsInvalidNamespaceAndName(t *testing.T) {
+	service := Service{
+		Namespace:  "Dox",
+		Name:       "iam-service-",
+		InstanceID: "server-pod-1",
+	}
 
-	if err := app.Validate(); !hasValidationField(err, "Application.service", "dox_kebab") {
-		t.Fatalf("expected invalid service validation error, got %v", err)
+	err := service.Validate()
+	if !hasValidationField(err, "Service.namespace", "dox_kebab") {
+		t.Fatalf("expected invalid namespace validation error, got %v", err)
+	}
+	if !hasValidationField(err, "Service.name", "dox_kebab") {
+		t.Fatalf("expected invalid service name validation error, got %v", err)
 	}
 }
 
-func TestApplicationValidateRejectsTrailingHyphen(t *testing.T) {
-	app := validApplication()
-	app.Service = "dox-server-"
+func TestServicesMayShareInstanceID(t *testing.T) {
+	services := []Service{
+		{Namespace: "dox", Name: "iam", InstanceID: "server-pod-abc"},
+		{Namespace: "dox", Name: "audit", InstanceID: "server-pod-abc"},
+	}
 
-	if err := app.Validate(); !hasValidationField(err, "Application.service", "dox_kebab") {
-		t.Fatalf("expected invalid service validation error, got %v", err)
+	for _, service := range services {
+		if err := service.Validate(); err != nil {
+			t.Fatalf("validate service %+v: %v", service, err)
+		}
+	}
+}
+
+func TestServiceValidateRejectsInvalidInstanceID(t *testing.T) {
+	service := Service{
+		Namespace:  "dox",
+		Name:       "iam",
+		InstanceID: "server-pod-",
+	}
+
+	if err := service.Validate(); !hasValidationField(err, "Service.instance_id", "dox_identifier") {
+		t.Fatalf("expected invalid instance_id validation error, got %v", err)
+	}
+}
+
+func TestOrganizationValidateRejectsInvalidGovernanceIdentifier(t *testing.T) {
+	organization := Organization{
+		Name:       "opendox",
+		Owner:      "Platform Team",
+		CostCenter: "dox-core",
+		Project:    "dox",
+	}
+
+	if err := organization.Validate(); !hasValidationField(err, "Organization.owner", "dox_identifier") {
+		t.Fatalf("expected invalid owner validation error, got %v", err)
 	}
 }
 
@@ -140,16 +220,6 @@ func TestRuntimeAndEnvValidity(t *testing.T) {
 	}
 	if Env("stage").IsValid() {
 		t.Fatal("did not expect unsupported env to be valid")
-	}
-}
-
-func validApplication() Application {
-	return Application{
-		Name:      "dox",
-		Namespace: "opendox",
-		Runtime:   RuntimeServer,
-		Service:   "dox-server",
-		Env:       EnvDev,
 	}
 }
 

--- a/packages/shared/setting/deployment.go
+++ b/packages/shared/setting/deployment.go
@@ -18,25 +18,29 @@
  * @File    : deployment.go
  * @Author  : Frost Leo <frostleo.dev@gmail.com>
  * @Created : 2026-04-25
- * @Modified: 2026-04-25
+ * @Modified: 2026-04-26
  */
 
 package setting
 
 import "errors"
 
-// Deployment describes where a Dox runtime process is deployed.
+// Deployment describes where a Dox runtime or service is deployed.
 type Deployment struct {
-	Region     string `json:"region" yaml:"region" mapstructure:"region" validate:"omitempty,dox_identifier"`
-	Zone       string `json:"zone" yaml:"zone" mapstructure:"zone" validate:"omitempty,dox_identifier"`
-	Cluster    string `json:"cluster" yaml:"cluster" mapstructure:"cluster" validate:"omitempty,dox_identifier"`
-	InstanceID string `json:"instance_id" yaml:"instance_id" mapstructure:"instance_id" validate:"omitempty,dox_identifier"`
+	Env          Env    `json:"env" yaml:"env" mapstructure:"env" validate:"required,dox_env"`
+	Region       string `json:"region" yaml:"region" mapstructure:"region" validate:"omitempty,dox_identifier"`
+	Zone         string `json:"zone" yaml:"zone" mapstructure:"zone" validate:"omitempty,dox_identifier"`
+	Cluster      string `json:"cluster" yaml:"cluster" mapstructure:"cluster" validate:"omitempty,dox_identifier"`
+	K8sNamespace string `json:"k8s_namespace" yaml:"k8s_namespace" mapstructure:"k8s_namespace" validate:"omitempty,dox_identifier"`
 }
 
-// Default is currently a no-op because deployment identity is environment-specific.
+// Default fills stable shared deployment defaults.
 func (d *Deployment) Default() error {
 	if d == nil {
 		return errors.New("setting: deployment must not be nil")
+	}
+	if d.Env == "" {
+		d.Env = EnvDev
 	}
 	return nil
 }

--- a/packages/shared/setting/deployment_test.go
+++ b/packages/shared/setting/deployment_test.go
@@ -18,7 +18,7 @@
  * @File    : deployment_test.go
  * @Author  : Frost Leo <frostleo.dev@gmail.com>
  * @Created : 2026-04-25
- * @Modified: 2026-04-25
+ * @Modified: 2026-04-26
  */
 
 package setting
@@ -31,6 +31,9 @@ func TestDeploymentAllowsEmptyIdentity(t *testing.T) {
 	if err := deployment.Default(); err != nil {
 		t.Fatalf("default deployment: %v", err)
 	}
+	if deployment.Env != EnvDev {
+		t.Fatalf("expected default env dev, got %q", deployment.Env)
+	}
 	if err := deployment.Validate(); err != nil {
 		t.Fatalf("validate empty deployment: %v", err)
 	}
@@ -38,10 +41,11 @@ func TestDeploymentAllowsEmptyIdentity(t *testing.T) {
 
 func TestDeploymentValidateAcceptsStableIdentifiers(t *testing.T) {
 	deployment := Deployment{
-		Region:     "us-east-1",
-		Zone:       "us-east-1a",
-		Cluster:    "dox-prod-1",
-		InstanceID: "dox-server-7f9d4c9b6d-x2m9k",
+		Env:          EnvProd,
+		Region:       "us-east-1",
+		Zone:         "us-east-1a",
+		Cluster:      "dox-prod-1",
+		K8sNamespace: "dox-prod",
 	}
 
 	if err := deployment.Validate(); err != nil {
@@ -51,10 +55,11 @@ func TestDeploymentValidateAcceptsStableIdentifiers(t *testing.T) {
 
 func TestDeploymentValidateRejectsInvalidIdentifier(t *testing.T) {
 	deployment := Deployment{
-		Region:     "us-east-1",
-		Zone:       "us-east-1a",
-		Cluster:    "Dox Prod",
-		InstanceID: "dox-server-1",
+		Env:          EnvProd,
+		Region:       "us-east-1",
+		Zone:         "us-east-1a",
+		Cluster:      "Dox Prod",
+		K8sNamespace: "dox-prod",
 	}
 
 	if err := deployment.Validate(); !hasValidationField(err, "Deployment.cluster", "dox_identifier") {
@@ -62,12 +67,13 @@ func TestDeploymentValidateRejectsInvalidIdentifier(t *testing.T) {
 	}
 }
 
-func TestDeploymentValidateRejectsTrailingSeparator(t *testing.T) {
+func TestDeploymentValidateRejectsTrailingNamespaceSeparator(t *testing.T) {
 	deployment := Deployment{
-		InstanceID: "dox-server-",
+		Env:          EnvProd,
+		K8sNamespace: "dox-prod-",
 	}
 
-	if err := deployment.Validate(); !hasValidationField(err, "Deployment.instance_id", "dox_identifier") {
-		t.Fatalf("expected invalid instance_id validation error, got %v", err)
+	if err := deployment.Validate(); !hasValidationField(err, "Deployment.k8s_namespace", "dox_identifier") {
+		t.Fatalf("expected invalid k8s_namespace validation error, got %v", err)
 	}
 }

--- a/packages/shared/setting/doc.go
+++ b/packages/shared/setting/doc.go
@@ -18,13 +18,14 @@
  * @File    : doc.go
  * @Author  : Frost Leo <frostleo.dev@gmail.com>
  * @Created : 2026-04-25
- * @Modified: 2026-04-25
+ * @Modified: 2026-04-26
  */
 
-// Package setting defines shared Dox runtime identity setting fragments.
+// Package setting defines shared Dox identity setting fragments.
 //
 // The package intentionally contains reusable identity fragments such as
-// Application and Deployment. It is not a global runtime Setting aggregate.
-// Each Dox runtime owns its concrete setting aggregate and may compose these
-// fragments when their semantics match that runtime.
+// Organization, Application, System, Service, and Deployment. It is not a
+// global runtime Setting aggregate, service registry, deployment manifest
+// model, or metrics model. Each Dox runtime owns its concrete setting aggregate
+// and may compose these fragments when their semantics match that runtime.
 package setting


### PR DESCRIPTION
## Description

Refines the shared setting identity model so Dox ownership, product family, runtime system, logical service, and deployment location are separate fragments instead of being overloaded into `Application` and `Deployment`.

## Related Links

- Closes #22
- Refs #20

## Scope

- [ ] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [ ] Security

## Implementation Notes

- Adds `Organization` for ownership/governance metadata.
- Narrows `Application` to the product/application family name.
- Adds `System` for the explicit Dox runtime identity: `server`, `scheduler`, `collector`, or `compute`.
- Adds `Service` for logical service identity: namespace, name, and optional instance ID.
- Moves environment and deployment location fields into `Deployment`.
- Keeps defaults conservative: no runtime is invented, service name only derives from explicit runtime, and deployment env defaults to `dev`.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands run:

```sh
env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go test -count=1 ./packages/shared/setting
env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go test -count=1 ./packages/shared/... ./server/...
git diff --check
```

Note: `go test -count=1 ./...` is not valid from the repository root because this workspace only includes `./packages/shared` and `./server` in `go.work`.

## Risks

Existing consumers of the newly introduced `Application` fields from #20 must move to the new fragments. Local searches and tests found no current production references outside `packages/shared/setting`.

## Commit References

- Current signed feature commit: `e570a42dd68a662524457a1c6bd4ed531b04d63b`
- Current signed develop merge commit: `60552f02c56c0d19347cdb26eced4416be1c0936`
- Note: commit messages were rewritten after merge to remove extra paragraph breaks from the 2026-04-26 commit bodies.