### PR TITLE
gh-24 [feat]: Add server setting identity aggregate

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -18,14 +18,14 @@
   @File    : server/README.md
   @Author  : Frost Leo <frostleo.dev@gmail.com>
   @Created : 2026-04-24
-  @Modified: 2026-04-25
+  @Modified: 2026-04-26
 -->
 
 # Dox Server
 
 `server` is the Web backend runtime for Dox.
 
-The current module contains the CLI entrypoint, shared version command, and bootstrap configuration snapshot loading. HTTP server startup, concrete runtime setting definitions, logging, database access, and EDA integration are intentionally out of scope for this milestone.
+The current module contains the CLI entrypoint, shared version command, bootstrap configuration snapshot loading, and the initial server-owned identity setting aggregate. HTTP server startup, database access, logging, security, and EDA integration are intentionally out of scope for this milestone.
 
 ## Configuration Bootstrap
 
@@ -38,7 +38,7 @@ The current bootstrap convention is:
 - `configs/local.<format>` as an optional local override;
 - `DOX_SERVER_` environment variables as optional final overrides.
 
-The bootstrap snapshot currently uses `map[string]any`. Concrete HTTP, database, cache, logger, security, and IAM setting structs remain out of scope until those runtime resources are introduced.
+The bootstrap snapshot currently uses `map[string]any`. Concrete server setting groups belong under `server/internal/setting`, where each configuration group owns its own file. The first group is identity; concrete HTTP, database, cache, logger, security, and IAM setting structs remain out of scope until those runtime resources are introduced.
 
 ## Usage
 

--- a/server/internal/setting/README.md
+++ b/server/internal/setting/README.md
@@ -1,0 +1,70 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : server/internal/setting/README.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-26
+  @Modified: 2026-04-26
+-->
+
+# Server Setting
+
+`server/internal/setting` owns the concrete configuration aggregate for the Dox Web backend runtime.
+
+Shared packages provide reusable configuration fragments. This package decides how the server runtime composes those fragments, which defaults are server-specific, and which validation rules are stricter than the shared fragment rules.
+
+## Boundaries
+
+- `server/internal/bootstrap` loads source snapshots from files and environment variables.
+- `packages/shared/config` provides source loading, merging, and decoding primitives.
+- `packages/shared/setting` defines reusable setting fragments.
+- `server/internal/setting` defines the server runtime aggregate and group-level semantics.
+
+Bootstrap should not own concrete HTTP, database, identity, logging, or security setting structs. It should continue to provide loaded values and diagnostics.
+
+## File Convention
+
+Use one file per configuration group:
+
+- `setting.go` defines the root `Setting` aggregate.
+- `identity.go` defines the identity group.
+- Future `database.go`, `http.go`, `logging.go`, `security.go`, and similar files should define their own focused groups.
+
+The root aggregate should compose groups instead of flattening every field:
+
+```go
+type Setting struct {
+    Identity Identity `json:"identity" yaml:"identity" mapstructure:"identity"`
+    Database Database `json:"database" yaml:"database" mapstructure:"database"`
+}
+```
+
+Callers should pass narrow group settings to subsystems instead of passing the full root setting everywhere.
+
+## Identity
+
+The identity group composes shared identity fragments:
+
+- `Organization`: ownership and governance metadata.
+- `Application`: product or application family.
+- `System`: Dox runtime identity.
+- `Service`: logical service identity.
+- `Deployment`: deployment environment and location.
+
+The server package defaults `System.Runtime` to `server`. That default does not belong in `packages/shared/setting`, because scheduler, collector, and compute runtimes must own their own runtime identity.
+
+`Deployment.Env` may be seeded from the bootstrap environment when the final server setting is created. If no seed or explicit value is provided, it falls back to the shared deployment default.

--- a/server/internal/setting/doc.go
+++ b/server/internal/setting/doc.go
@@ -1,0 +1,29 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : doc.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-26
+ * @Modified: 2026-04-26
+ */
+
+// Package setting defines the concrete configuration aggregate for the Dox
+// Web backend runtime.
+//
+// Shared packages define reusable fragments. This package owns the server
+// runtime composition, defaulting order, and server-specific validation rules.
+package setting

--- a/server/internal/setting/identity.go
+++ b/server/internal/setting/identity.go
@@ -1,0 +1,108 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : identity.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-26
+ * @Modified: 2026-04-26
+ */
+
+package setting
+
+import (
+	"errors"
+	"strings"
+
+	sharedsetting "github.com/opendox/dox/packages/shared/setting"
+)
+
+const (
+	// ServerRuntime is the Dox runtime identity owned by the Web backend server.
+	ServerRuntime = sharedsetting.RuntimeServer
+)
+
+var (
+	// ErrInvalidServerRuntime reports a supported Dox runtime that is not server.
+	ErrInvalidServerRuntime = errors.New("server setting: identity.system.runtime must be server")
+)
+
+// IdentityDefaultOptions carries bootstrap-derived identity defaults.
+type IdentityDefaultOptions struct {
+	Env string
+}
+
+// Identity groups the shared identity fragments used by the server runtime.
+type Identity struct {
+	Organization sharedsetting.Organization `json:"organization" yaml:"organization" mapstructure:"organization"`
+	Application  sharedsetting.Application  `json:"application" yaml:"application" mapstructure:"application"`
+	System       sharedsetting.System       `json:"system" yaml:"system" mapstructure:"system"`
+	Service      sharedsetting.Service      `json:"service" yaml:"service" mapstructure:"service"`
+	Deployment   sharedsetting.Deployment   `json:"deployment" yaml:"deployment" mapstructure:"deployment"`
+}
+
+// Default fills stable server identity defaults without bootstrap-derived values.
+func (i *Identity) Default() error {
+	return i.DefaultWithOptions(IdentityDefaultOptions{})
+}
+
+// DefaultWithOptions fills stable server identity defaults and optional bootstrap-derived values.
+func (i *Identity) DefaultWithOptions(options IdentityDefaultOptions) error {
+	if i == nil {
+		return errors.New("server setting: identity must not be nil")
+	}
+	if err := i.Organization.Default(); err != nil {
+		return err
+	}
+	if err := i.Application.Default(); err != nil {
+		return err
+	}
+	if err := i.System.Default(); err != nil {
+		return err
+	}
+	if i.System.Runtime == "" {
+		i.System.Runtime = ServerRuntime
+	}
+	if err := i.Service.Default(i.Application, i.System); err != nil {
+		return err
+	}
+	if i.Deployment.Env == "" {
+		i.Deployment.Env = sharedsetting.Env(strings.TrimSpace(options.Env))
+	}
+	if err := i.Deployment.Default(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Validate verifies shared identity fragments plus server-owned runtime rules.
+func (i Identity) Validate() error {
+	return errors.Join(
+		i.Organization.Validate(),
+		i.Application.Validate(),
+		i.System.Validate(),
+		i.validateServerRuntime(),
+		i.Service.Validate(),
+		i.Deployment.Validate(),
+	)
+}
+
+func (i Identity) validateServerRuntime() error {
+	if i.System.Runtime.IsValid() && i.System.Runtime != ServerRuntime {
+		return ErrInvalidServerRuntime
+	}
+	return nil
+}

--- a/server/internal/setting/identity_test.go
+++ b/server/internal/setting/identity_test.go
@@ -1,0 +1,157 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : identity_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-26
+ * @Modified: 2026-04-26
+ */
+
+package setting
+
+import (
+	"errors"
+	"testing"
+
+	sharedsetting "github.com/opendox/dox/packages/shared/setting"
+)
+
+func TestIdentityDefaultAppliesServerIdentity(t *testing.T) {
+	identity := Identity{}
+
+	if err := identity.DefaultWithOptions(IdentityDefaultOptions{Env: "staging"}); err != nil {
+		t.Fatalf("default identity: %v", err)
+	}
+
+	if identity.Organization.Name != sharedsetting.DefaultOrganizationName {
+		t.Fatalf("expected default organization, got %q", identity.Organization.Name)
+	}
+	if identity.Application.Name != sharedsetting.DefaultApplicationName {
+		t.Fatalf("expected default application, got %q", identity.Application.Name)
+	}
+	if identity.System.Runtime != ServerRuntime {
+		t.Fatalf("expected server runtime, got %q", identity.System.Runtime)
+	}
+	if identity.Service.Namespace != sharedsetting.DefaultApplicationName {
+		t.Fatalf("expected service namespace from application, got %q", identity.Service.Namespace)
+	}
+	if identity.Service.Name != string(ServerRuntime) {
+		t.Fatalf("expected service name from runtime, got %q", identity.Service.Name)
+	}
+	if identity.Deployment.Env != sharedsetting.EnvStaging {
+		t.Fatalf("expected deployment env from options, got %q", identity.Deployment.Env)
+	}
+	if err := identity.Validate(); err != nil {
+		t.Fatalf("validate identity: %v", err)
+	}
+}
+
+func TestIdentityDefaultPreservesExplicitValues(t *testing.T) {
+	identity := Identity{
+		Application: sharedsetting.Application{Name: "dox"},
+		System:      sharedsetting.System{Runtime: ServerRuntime},
+		Service: sharedsetting.Service{
+			Namespace:  "platform",
+			Name:       "iam",
+			InstanceID: "server-pod-1",
+		},
+		Deployment: sharedsetting.Deployment{Env: sharedsetting.EnvProd},
+	}
+
+	if err := identity.DefaultWithOptions(IdentityDefaultOptions{Env: "staging"}); err != nil {
+		t.Fatalf("default identity: %v", err)
+	}
+
+	if identity.Service.Namespace != "platform" {
+		t.Fatalf("expected explicit service namespace to remain, got %q", identity.Service.Namespace)
+	}
+	if identity.Service.Name != "iam" {
+		t.Fatalf("expected explicit service name to remain, got %q", identity.Service.Name)
+	}
+	if identity.Service.InstanceID != "server-pod-1" {
+		t.Fatalf("expected explicit service instance id to remain, got %q", identity.Service.InstanceID)
+	}
+	if identity.Deployment.Env != sharedsetting.EnvProd {
+		t.Fatalf("expected explicit deployment env to remain, got %q", identity.Deployment.Env)
+	}
+	if err := identity.Validate(); err != nil {
+		t.Fatalf("validate identity: %v", err)
+	}
+}
+
+func TestIdentityDefaultFallsBackToSharedDeploymentEnv(t *testing.T) {
+	identity := Identity{}
+
+	if err := identity.Default(); err != nil {
+		t.Fatalf("default identity: %v", err)
+	}
+	if identity.Deployment.Env != sharedsetting.EnvDev {
+		t.Fatalf("expected shared deployment env default, got %q", identity.Deployment.Env)
+	}
+}
+
+func TestIdentityValidateRejectsNonServerRuntime(t *testing.T) {
+	identity := validIdentity()
+	identity.System.Runtime = sharedsetting.RuntimeScheduler
+
+	if err := identity.Validate(); !errors.Is(err, ErrInvalidServerRuntime) {
+		t.Fatalf("expected invalid server runtime error, got %v", err)
+	}
+}
+
+func TestIdentityValidateRejectsSharedIdentityFailures(t *testing.T) {
+	identity := validIdentity()
+	identity.Service.Name = "Dox Server"
+
+	if err := identity.Validate(); !hasSharedValidationField(err, "Service.name", "dox_kebab") {
+		t.Fatalf("expected shared service validation error, got %v", err)
+	}
+}
+
+func TestIdentityDefaultRejectsNilReceiver(t *testing.T) {
+	var identity *Identity
+
+	if err := identity.Default(); err == nil {
+		t.Fatal("expected nil identity default error")
+	}
+}
+
+func validIdentity() Identity {
+	return Identity{
+		Organization: sharedsetting.Organization{Name: sharedsetting.DefaultOrganizationName},
+		Application:  sharedsetting.Application{Name: sharedsetting.DefaultApplicationName},
+		System:       sharedsetting.System{Runtime: ServerRuntime},
+		Service: sharedsetting.Service{
+			Namespace: sharedsetting.DefaultApplicationName,
+			Name:      string(ServerRuntime),
+		},
+		Deployment: sharedsetting.Deployment{Env: sharedsetting.EnvDev},
+	}
+}
+
+func hasSharedValidationField(err error, field string, rule string) bool {
+	var validationErr *sharedsetting.ValidationError
+	if !errors.As(err, &validationErr) {
+		return false
+	}
+	for _, item := range validationErr.Fields {
+		if item.Field == field && item.Rule == rule {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/setting/setting.go
+++ b/server/internal/setting/setting.go
@@ -1,0 +1,56 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : setting.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-26
+ * @Modified: 2026-04-26
+ */
+
+package setting
+
+import "errors"
+
+// DefaultOptions carries bootstrap-derived values that can seed server settings.
+type DefaultOptions struct {
+	Env string
+}
+
+// Setting is the root configuration aggregate for the Dox Web backend runtime.
+type Setting struct {
+	Identity Identity `json:"identity" yaml:"identity" mapstructure:"identity"`
+}
+
+// Default fills stable server defaults without bootstrap-derived values.
+func (s *Setting) Default() error {
+	return s.DefaultWithOptions(DefaultOptions{})
+}
+
+// DefaultWithOptions fills stable server defaults and optional bootstrap-derived values.
+func (s *Setting) DefaultWithOptions(options DefaultOptions) error {
+	if s == nil {
+		return errors.New("server setting: setting must not be nil")
+	}
+	return s.Identity.DefaultWithOptions(IdentityDefaultOptions{
+		Env: options.Env,
+	})
+}
+
+// Validate verifies the concrete server configuration aggregate.
+func (s Setting) Validate() error {
+	return s.Identity.Validate()
+}

--- a/server/internal/setting/setting_test.go
+++ b/server/internal/setting/setting_test.go
@@ -1,0 +1,142 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : setting_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-26
+ * @Modified: 2026-04-26
+ */
+
+package setting
+
+import (
+	"context"
+	"testing"
+
+	sharedconfig "github.com/opendox/dox/packages/shared/config"
+	sharedsetting "github.com/opendox/dox/packages/shared/setting"
+)
+
+func TestSettingDefaultAppliesIdentityDefaults(t *testing.T) {
+	setting := Setting{}
+
+	if err := setting.DefaultWithOptions(DefaultOptions{Env: "test"}); err != nil {
+		t.Fatalf("default setting: %v", err)
+	}
+	if setting.Identity.System.Runtime != ServerRuntime {
+		t.Fatalf("expected server runtime, got %q", setting.Identity.System.Runtime)
+	}
+	if setting.Identity.Deployment.Env != sharedsetting.EnvTest {
+		t.Fatalf("expected deployment env from options, got %q", setting.Identity.Deployment.Env)
+	}
+	if err := setting.Validate(); err != nil {
+		t.Fatalf("validate setting: %v", err)
+	}
+}
+
+func TestSettingDecodeValuesSupportsNestedIdentity(t *testing.T) {
+	values := map[string]any{
+		"identity": map[string]any{
+			"organization": map[string]any{
+				"name":        "opendox",
+				"owner":       "platform",
+				"cost_center": "dox-core",
+			},
+			"application": map[string]any{
+				"name": "dox",
+			},
+			"service": map[string]any{
+				"name":        "iam",
+				"instance_id": "server-pod-1",
+			},
+			"deployment": map[string]any{
+				"region":        "us-east-1",
+				"zone":          "us-east-1a",
+				"cluster":       "dox-prod-1",
+				"k8s_namespace": "dox-prod",
+			},
+		},
+	}
+
+	setting := Setting{}
+	if err := sharedconfig.DecodeValues(context.Background(), values, &setting, sharedconfig.Options{}); err != nil {
+		t.Fatalf("decode setting: %v", err)
+	}
+	if err := setting.DefaultWithOptions(DefaultOptions{Env: "prod"}); err != nil {
+		t.Fatalf("default setting: %v", err)
+	}
+	if err := setting.Validate(); err != nil {
+		t.Fatalf("validate setting: %v", err)
+	}
+
+	if setting.Identity.System.Runtime != ServerRuntime {
+		t.Fatalf("expected server runtime default, got %q", setting.Identity.System.Runtime)
+	}
+	if setting.Identity.Service.Namespace != "dox" {
+		t.Fatalf("expected service namespace from application, got %q", setting.Identity.Service.Namespace)
+	}
+	if setting.Identity.Service.Name != "iam" {
+		t.Fatalf("expected explicit service name, got %q", setting.Identity.Service.Name)
+	}
+	if setting.Identity.Deployment.Env != sharedsetting.EnvProd {
+		t.Fatalf("expected deployment env from bootstrap option, got %q", setting.Identity.Deployment.Env)
+	}
+}
+
+func TestSettingValidateRejectsInvalidDecodedIdentity(t *testing.T) {
+	values := map[string]any{
+		"identity": map[string]any{
+			"system": map[string]any{
+				"runtime": "server",
+			},
+			"service": map[string]any{
+				"namespace": "dox",
+				"name":      "iam-",
+			},
+		},
+	}
+
+	setting := Setting{}
+	if err := sharedconfig.DecodeValues(context.Background(), values, &setting, sharedconfig.Options{}); err != nil {
+		t.Fatalf("decode setting: %v", err)
+	}
+	if err := setting.Default(); err != nil {
+		t.Fatalf("default setting: %v", err)
+	}
+	if err := setting.Validate(); !hasSharedValidationField(err, "Service.name", "dox_kebab") {
+		t.Fatalf("expected invalid decoded service name, got %v", err)
+	}
+}
+
+func TestSettingValidateRejectsInvalidBootstrapEnv(t *testing.T) {
+	setting := Setting{}
+
+	if err := setting.DefaultWithOptions(DefaultOptions{Env: "production"}); err != nil {
+		t.Fatalf("default setting: %v", err)
+	}
+	if err := setting.Validate(); !hasSharedValidationField(err, "Deployment.env", "dox_env") {
+		t.Fatalf("expected invalid bootstrap env validation error, got %v", err)
+	}
+}
+
+func TestSettingDefaultRejectsNilReceiver(t *testing.T) {
+	var setting *Setting
+
+	if err := setting.Default(); err == nil {
+		t.Fatal("expected nil setting default error")
+	}
+}


### PR DESCRIPTION
## Description

Adds the server-owned setting package and introduces the first concrete server setting group: identity. The package composes shared identity fragments without moving concrete setting ownership into `packages/shared/setting` or `server/internal/bootstrap`.

## Related Links

- Closes #24
- Refs #22
- Refs #20

## Scope

- [x] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [ ] Security

## Implementation Notes

- Adds `server/internal/setting.Setting` as the root aggregate.
- Adds `server/internal/setting.Identity` as the first one-configuration-group-per-file setting group.
- Composes shared `Organization`, `Application`, `System`, `Service`, and `Deployment` fragments.
- Defaults `System.Runtime` to `server` only in the server package.
- Supports bootstrap env seeding through `DefaultWithOptions(DefaultOptions{Env: ...})`.
- Keeps `server/internal/bootstrap` source-oriented and updates README guidance for future `database.go`, `http.go`, `logging.go`, and similar groups.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands run:

```sh
env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go test -count=1 ./server/internal/setting
env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go test -count=1 ./packages/shared/... ./server/...
git diff --cached --check
```

## Risks

The new setting package is not yet wired into server startup commands. That integration should wait until server startup needs a concrete runtime setting object beyond the current bootstrap snapshot.

## Commit References

- Current signed feature commit: `96da1c6f55f1a96118fb695c370501963d084af5`
- Current signed develop merge commit: `a21482152ece94a67002b869bf2ff6c1dfae25ed`
- Note: commit messages were rewritten after merge to remove extra paragraph breaks from the 2026-04-26 commit bodies.