### PR TITLE
gh-26 [feat]: Add shared logging model contract

### DIFF
--- a/packages/shared/logging/README.md
+++ b/packages/shared/logging/README.md
@@ -34,7 +34,6 @@ The package owns stable names and configuration shapes for:
 - resource identity;
 - correlation identity;
 - observability event classification;
-- EDA domain/message event metadata;
 - service-internal node fields;
 - low-cardinality business tags;
 - event facts and higher-cardinality fields;
@@ -45,7 +44,7 @@ The package must not:
 - expose `*zap.Logger`, `zap.Field`, or `zap.Config` as a business API;
 - import zap, lumberjack, or OpenTelemetry SDK packages in this first stage;
 - write logs to console, files, stdout, stderr, OTLP, or async queues;
-- wire logging into server, scheduler, collector, compute, IAM, HTTP middleware, or EDA runtime packages.
+- wire logging into server, scheduler, collector, compute, IAM, or HTTP middleware.
 
 ## Resource
 
@@ -72,7 +71,7 @@ dox.runtime
 
 ## Correlation
 
-Correlation fields connect one request, task, plugin execution, or EDA chain:
+Correlation fields connect one request, task, plugin execution, or cross-runtime chain:
 
 ```text
 trace_id
@@ -89,7 +88,7 @@ plugin_run_id
 
 `trace_id`, `span_id`, and `trace_flags` align with OpenTelemetry. `correlation_id` is Dox-owned and must survive across request, task, event, and plugin boundaries.
 
-## Observability Events And EDA Events
+## Observability Events
 
 `event.*` describes what the log record observes:
 
@@ -102,36 +101,15 @@ event.action
 event.outcome
 ```
 
-`eda.*` describes a domain or message event involved in the observed action:
-
-```text
-eda.event_id
-eda.event_type
-eda.event_version
-eda.event_source
-eda.subject
-eda.correlation_id
-eda.causation_id
-eda.message_id
-eda.topic
-eda.partition
-eda.offset
-eda.consumer_group
-eda.consumer_id
-eda.delivery_attempt
-```
-
 Example:
 
 ```text
-event.name = eda.event.published
-event.action = publish
-event.outcome = success
-
-eda.event_id = evt_001
-eda.event_type = iam.login.failed
-eda.topic = iam.login
-eda.message_id = msg_001
+event.name = iam.login.rejected
+event.dataset = dox.iam.security
+event.category = authentication
+event.type = denied
+event.action = login
+event.outcome = failure
 ```
 
 There is no first-class `channel` field. Dataset, category, type, action, and outcome carry that classification.
@@ -260,6 +238,5 @@ Separate issues should implement:
 - server setting and bootstrap integration;
 - HTTP correlation middleware;
 - IAM login chain sample;
-- EDA publisher and consumer logging;
 - scheduler, collector, and compute integration;
 - Filebeat, Fluent Bit, and OpenTelemetry Collector examples.

--- a/packages/shared/logging/README.md
+++ b/packages/shared/logging/README.md
@@ -1,0 +1,265 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : packages/shared/logging/README.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-26
+  @Modified: 2026-04-26
+-->
+
+# Shared Logging Model Contract
+
+`packages/shared/logging` defines the shared Dox logging vocabulary and configuration contract.
+
+This package does not initialize zap, lumberjack, OpenTelemetry SDK providers, runtime loggers, or concrete sinks. Those belong to follow-up implementation work.
+
+## Boundary
+
+The package owns stable names and configuration shapes for:
+
+- resource identity;
+- correlation identity;
+- observability event classification;
+- EDA domain/message event metadata;
+- service-internal node fields;
+- low-cardinality business tags;
+- event facts and higher-cardinality fields;
+- zap-facing, rotation, buffering, redaction, and OpenTelemetry configuration shapes.
+
+The package must not:
+
+- expose `*zap.Logger`, `zap.Field`, or `zap.Config` as a business API;
+- import zap, lumberjack, or OpenTelemetry SDK packages in this first stage;
+- write logs to console, files, stdout, stderr, OTLP, or async queues;
+- wire logging into server, scheduler, collector, compute, IAM, HTTP middleware, or EDA runtime packages.
+
+## Resource
+
+Resource fields answer who produced telemetry:
+
+```text
+service.namespace
+service.name
+service.instance.id
+service.version
+deployment.environment.name
+cloud.region
+cloud.availability_zone
+k8s.cluster.name
+k8s.namespace.name
+dox.organization
+dox.application
+dox.runtime
+```
+
+`dox.runtime` identifies one Dox runtime: `server`, `scheduler`, `collector`, or `compute`.
+
+`service.name` identifies a service capability and is not the same as runtime. For example, the `server` runtime can host the `iam` service.
+
+## Correlation
+
+Correlation fields connect one request, task, plugin execution, or EDA chain:
+
+```text
+trace_id
+span_id
+trace_flags
+request_id
+correlation_id
+job_id
+task_id
+workflow_id
+plugin_id
+plugin_run_id
+```
+
+`trace_id`, `span_id`, and `trace_flags` align with OpenTelemetry. `correlation_id` is Dox-owned and must survive across request, task, event, and plugin boundaries.
+
+## Observability Events And EDA Events
+
+`event.*` describes what the log record observes:
+
+```text
+event.name
+event.dataset
+event.category
+event.type
+event.action
+event.outcome
+```
+
+`eda.*` describes a domain or message event involved in the observed action:
+
+```text
+eda.event_id
+eda.event_type
+eda.event_version
+eda.event_source
+eda.subject
+eda.correlation_id
+eda.causation_id
+eda.message_id
+eda.topic
+eda.partition
+eda.offset
+eda.consumer_group
+eda.consumer_id
+eda.delivery_attempt
+```
+
+Example:
+
+```text
+event.name = eda.event.published
+event.action = publish
+event.outcome = success
+
+eda.event_id = evt_001
+eda.event_type = iam.login.failed
+eda.topic = iam.login
+eda.message_id = msg_001
+```
+
+There is no first-class `channel` field. Dataset, category, type, action, and outcome carry that classification.
+
+## Tags Versus Fields
+
+`tags` are low-cardinality business labels declared by the current node. They are suitable for dropdown filters, grouping, and alert routing.
+
+Good tags:
+
+```text
+risk_level
+login_method
+credential_type
+reject_reason
+provider
+queue
+worker_pool
+retryable
+rate_limit_bucket
+```
+
+Do not put these into tags:
+
+```text
+runtime
+service
+env
+region
+component
+operation
+trace_id
+request_id
+correlation_id
+user_id
+account
+duration_ms
+error_message
+```
+
+Those values are resource fields, node fields, correlation fields, or event facts.
+
+## IAM Login Rejected Example
+
+```json
+{
+  "service.namespace": "dox",
+  "service.name": "iam",
+  "service.instance.id": "server-01",
+  "service.version": "0.1.0",
+  "dox.runtime": "server",
+  "deployment.environment.name": "prod",
+  "trace_id": "trace_001",
+  "span_id": "span_auth_001",
+  "request_id": "req_001",
+  "correlation_id": "corr_001",
+  "event.name": "iam.login.rejected",
+  "event.dataset": "dox.iam.security",
+  "event.category": "authentication",
+  "event.type": "denied",
+  "event.action": "login",
+  "event.outcome": "failure",
+  "component": "auth_service",
+  "operation": "verify_credential",
+  "tags": {
+    "risk_level": "medium",
+    "login_method": "password",
+    "credential_type": "password",
+    "reject_reason": "invalid_password"
+  },
+  "fields": {
+    "account": "alice@example.com",
+    "tenant_id": "tenant_a",
+    "client_ip": "203.0.113.10",
+    "failed_attempts": 3
+  }
+}
+```
+
+## Configuration Shape
+
+The configuration contract includes:
+
+- root logging settings;
+- zap-facing configuration shape;
+- per-core declarations for future console and file sinks;
+- rotation configuration for future lumberjack v2 mapping;
+- buffering and shutdown settings;
+- redaction policy;
+- OpenTelemetry propagation, traces, metrics, logs, OTLP exporter, and batch settings.
+
+The default core declarations are:
+
+```yaml
+cores:
+  - name: console
+    enabled: true
+    type: console
+    encoding: console
+    output_paths: ["stdout"]
+    datasets: ["*"]
+  - name: service-file
+    enabled: true
+    type: file
+    encoding: json
+    output_paths: ["logs/${service.namespace}-${service.name}.jsonl"]
+    datasets: ["*"]
+    rotation:
+      driver: lumberjack
+      enabled: true
+      max_size_mb: 100
+      max_backups: 10
+      max_age_days: 14
+      compress: true
+      local_time: true
+```
+
+## Follow-Up Work
+
+Separate issues should implement:
+
+- zap core base;
+- JSONL file sink and lumberjack v2 rotation;
+- Dox logger API and context correlation;
+- OpenTelemetry SDK base;
+- server setting and bootstrap integration;
+- HTTP correlation middleware;
+- IAM login chain sample;
+- EDA publisher and consumer logging;
+- scheduler, collector, and compute integration;
+- Filebeat, Fluent Bit, and OpenTelemetry Collector examples.

--- a/packages/shared/logging/config.go
+++ b/packages/shared/logging/config.go
@@ -215,7 +215,7 @@ type SamplingConfig struct {
 // CoreConfig declares one future zapcore output core.
 type CoreConfig struct {
 	Name        string         `json:"name" yaml:"name" mapstructure:"name"`
-	Enabled     bool           `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	Enabled     *bool          `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
 	Type        CoreType       `json:"type" yaml:"type" mapstructure:"type"`
 	Level       Level          `json:"level" yaml:"level" mapstructure:"level"`
 	Encoding    Encoding       `json:"encoding" yaml:"encoding" mapstructure:"encoding"`
@@ -227,17 +227,17 @@ type CoreConfig struct {
 // RotationConfig declares a future file rotation mapping.
 type RotationConfig struct {
 	Driver     RotationDriver `json:"driver" yaml:"driver" mapstructure:"driver"`
-	Enabled    bool           `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	Enabled    *bool          `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
 	MaxSizeMB  int            `json:"max_size_mb" yaml:"max_size_mb" mapstructure:"max_size_mb"`
 	MaxBackups int            `json:"max_backups" yaml:"max_backups" mapstructure:"max_backups"`
 	MaxAgeDays int            `json:"max_age_days" yaml:"max_age_days" mapstructure:"max_age_days"`
-	Compress   bool           `json:"compress" yaml:"compress" mapstructure:"compress"`
-	LocalTime  bool           `json:"local_time" yaml:"local_time" mapstructure:"local_time"`
+	Compress   *bool          `json:"compress" yaml:"compress" mapstructure:"compress"`
+	LocalTime  *bool          `json:"local_time" yaml:"local_time" mapstructure:"local_time"`
 }
 
 // BufferingConfig declares future buffered writer behavior.
 type BufferingConfig struct {
-	Enabled       bool          `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	Enabled       *bool         `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
 	SizeBytes     int           `json:"size_bytes" yaml:"size_bytes" mapstructure:"size_bytes"`
 	FlushInterval time.Duration `json:"flush_interval" yaml:"flush_interval" mapstructure:"flush_interval"`
 }
@@ -249,14 +249,14 @@ type ShutdownConfig struct {
 
 // RedactionConfig declares sensitive key replacement policy.
 type RedactionConfig struct {
-	Enabled     bool     `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	Enabled     *bool    `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
 	Replacement string   `json:"replacement" yaml:"replacement" mapstructure:"replacement"`
 	Keys        []string `json:"keys" yaml:"keys" mapstructure:"keys"`
 }
 
 // OpenTelemetryConfig declares future OpenTelemetry SDK integration settings.
 type OpenTelemetryConfig struct {
-	Enabled     bool                     `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	Enabled     *bool                    `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
 	Propagation OpenTelemetryPropagation `json:"propagation" yaml:"propagation" mapstructure:"propagation"`
 	Traces      OpenTelemetryTraces      `json:"traces" yaml:"traces" mapstructure:"traces"`
 	Metrics     OpenTelemetrySignal      `json:"metrics" yaml:"metrics" mapstructure:"metrics"`
@@ -267,13 +267,13 @@ type OpenTelemetryConfig struct {
 
 // OpenTelemetryPropagation declares propagation settings.
 type OpenTelemetryPropagation struct {
-	TraceContext bool `json:"trace_context" yaml:"trace_context" mapstructure:"trace_context"`
-	Baggage      bool `json:"baggage" yaml:"baggage" mapstructure:"baggage"`
+	TraceContext *bool `json:"trace_context" yaml:"trace_context" mapstructure:"trace_context"`
+	Baggage      *bool `json:"baggage" yaml:"baggage" mapstructure:"baggage"`
 }
 
 // OpenTelemetryTraces declares trace settings.
 type OpenTelemetryTraces struct {
-	Enabled bool               `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	Enabled *bool              `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
 	Sampler TraceSamplerConfig `json:"sampler" yaml:"sampler" mapstructure:"sampler"`
 }
 
@@ -285,7 +285,7 @@ type TraceSamplerConfig struct {
 
 // OpenTelemetrySignal declares a simple OpenTelemetry signal toggle.
 type OpenTelemetrySignal struct {
-	Enabled bool `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	Enabled *bool `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
 }
 
 // OpenTelemetryExporter declares exporter settings.
@@ -298,7 +298,7 @@ type OTLPExporterConfig struct {
 	Enabled     bool              `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
 	Endpoint    string            `json:"endpoint" yaml:"endpoint" mapstructure:"endpoint"`
 	Protocol    OTLPProtocol      `json:"protocol" yaml:"protocol" mapstructure:"protocol"`
-	Insecure    bool              `json:"insecure" yaml:"insecure" mapstructure:"insecure"`
+	Insecure    *bool             `json:"insecure" yaml:"insecure" mapstructure:"insecure"`
 	Headers     map[string]string `json:"headers" yaml:"headers" mapstructure:"headers"`
 	Compression string            `json:"compression" yaml:"compression" mapstructure:"compression"`
 	Timeout     time.Duration     `json:"timeout" yaml:"timeout" mapstructure:"timeout"`
@@ -418,6 +418,7 @@ func (c *SamplingConfig) Default() {
 
 // Default fills core defaults.
 func (c *CoreConfig) Default(level Level) {
+	defaultBool(&c.Enabled, true)
 	if c.Level == "" {
 		c.Level = level
 	}
@@ -458,12 +459,14 @@ func (c *RotationConfig) Default() {
 		if c.MaxAgeDays == 0 {
 			c.MaxAgeDays = 14
 		}
-		c.Compress = true
-		c.LocalTime = true
+		defaultBool(&c.Compress, true)
+		defaultBool(&c.LocalTime, true)
 	}
 	if c.Driver != RotationDriverNone {
-		c.Enabled = true
+		defaultBool(&c.Enabled, true)
+		return
 	}
+	defaultBool(&c.Enabled, false)
 }
 
 // Default fills buffering defaults.
@@ -474,7 +477,7 @@ func (c *BufferingConfig) Default() {
 	if c.FlushInterval == 0 {
 		c.FlushInterval = time.Second
 	}
-	c.Enabled = true
+	defaultBool(&c.Enabled, true)
 }
 
 // Default fills shutdown defaults.
@@ -486,7 +489,7 @@ func (c *ShutdownConfig) Default() {
 
 // Default fills redaction defaults.
 func (c *RedactionConfig) Default() {
-	c.Enabled = true
+	defaultBool(&c.Enabled, true)
 	if c.Replacement == "" {
 		c.Replacement = DefaultRedactionReplacement
 	}
@@ -497,24 +500,24 @@ func (c *RedactionConfig) Default() {
 
 // Default fills OpenTelemetry configuration defaults.
 func (c *OpenTelemetryConfig) Default() {
-	c.Enabled = true
+	defaultBool(&c.Enabled, true)
 	c.Propagation.Default()
 	c.Traces.Default()
-	c.Metrics.Enabled = true
-	c.Logs.Enabled = true
+	defaultBool(&c.Metrics.Enabled, true)
+	defaultBool(&c.Logs.Enabled, true)
 	c.Exporter.Default()
 	c.Batch.Default()
 }
 
 // Default fills OpenTelemetry propagation defaults.
 func (c *OpenTelemetryPropagation) Default() {
-	c.TraceContext = true
-	c.Baggage = true
+	defaultBool(&c.TraceContext, true)
+	defaultBool(&c.Baggage, true)
 }
 
 // Default fills OpenTelemetry trace defaults.
 func (c *OpenTelemetryTraces) Default() {
-	c.Enabled = true
+	defaultBool(&c.Enabled, true)
 	c.Sampler.Default()
 }
 
@@ -541,7 +544,7 @@ func (c *OTLPExporterConfig) Default() {
 	if c.Protocol == "" {
 		c.Protocol = OTLPProtocolGRPC
 	}
-	c.Insecure = true
+	defaultBool(&c.Insecure, true)
 	if c.Headers == nil {
 		c.Headers = map[string]string{}
 	}
@@ -592,7 +595,7 @@ func DefaultRedactionKeys() []string {
 func defaultConsoleCore(level Level) CoreConfig {
 	return CoreConfig{
 		Name:        "console",
-		Enabled:     true,
+		Enabled:     boolPtr(true),
 		Type:        CoreTypeConsole,
 		Level:       level,
 		Encoding:    EncodingConsole,
@@ -604,7 +607,7 @@ func defaultConsoleCore(level Level) CoreConfig {
 func defaultServiceFileCore(level Level) CoreConfig {
 	return CoreConfig{
 		Name:        "service-file",
-		Enabled:     true,
+		Enabled:     boolPtr(true),
 		Type:        CoreTypeFile,
 		Level:       level,
 		Encoding:    EncodingJSON,
@@ -612,12 +615,27 @@ func defaultServiceFileCore(level Level) CoreConfig {
 		Datasets:    []string{"*"},
 		Rotation: RotationConfig{
 			Driver:     RotationDriverLumberjack,
-			Enabled:    true,
+			Enabled:    boolPtr(true),
 			MaxSizeMB:  100,
 			MaxBackups: 10,
 			MaxAgeDays: 14,
-			Compress:   true,
-			LocalTime:  true,
+			Compress:   boolPtr(true),
+			LocalTime:  boolPtr(true),
 		},
 	}
+}
+
+func defaultBool(target **bool, value bool) {
+	if *target == nil {
+		*target = boolPtr(value)
+	}
+}
+
+func boolPtr(value bool) *bool {
+	copied := value
+	return &copied
+}
+
+func boolValue(value *bool) bool {
+	return value != nil && *value
 }

--- a/packages/shared/logging/config.go
+++ b/packages/shared/logging/config.go
@@ -1,0 +1,623 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : config.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-26
+ * @Modified: 2026-04-26
+ */
+
+package logging
+
+import (
+	"errors"
+	"time"
+)
+
+const (
+	// DefaultFilePathTemplate is the default service JSONL log path template.
+	DefaultFilePathTemplate = "logs/${service.namespace}-${service.name}.jsonl"
+	// DefaultRedactionReplacement is the default replacement for sensitive values.
+	DefaultRedactionReplacement = "[REDACTED]"
+)
+
+// Level identifies a logging level accepted by the shared logging contract.
+type Level string
+
+const (
+	LevelDebug  Level = "debug"
+	LevelInfo   Level = "info"
+	LevelWarn   Level = "warn"
+	LevelError  Level = "error"
+	LevelDPanic Level = "dpanic"
+	LevelPanic  Level = "panic"
+	LevelFatal  Level = "fatal"
+)
+
+// IsValid reports whether l is a supported logging level.
+func (l Level) IsValid() bool {
+	switch l {
+	case LevelDebug, LevelInfo, LevelWarn, LevelError, LevelDPanic, LevelPanic, LevelFatal:
+		return true
+	default:
+		return false
+	}
+}
+
+// Encoding identifies a configured log encoder format.
+type Encoding string
+
+const (
+	EncodingConsole Encoding = "console"
+	EncodingJSON    Encoding = "json"
+)
+
+// IsValid reports whether e is a supported log encoding.
+func (e Encoding) IsValid() bool {
+	switch e {
+	case EncodingConsole, EncodingJSON:
+		return true
+	default:
+		return false
+	}
+}
+
+// CoreType identifies one configured zapcore-style output core.
+type CoreType string
+
+const (
+	CoreTypeConsole CoreType = "console"
+	CoreTypeFile    CoreType = "file"
+)
+
+// IsValid reports whether t is a supported core type.
+func (t CoreType) IsValid() bool {
+	switch t {
+	case CoreTypeConsole, CoreTypeFile:
+		return true
+	default:
+		return false
+	}
+}
+
+// RotationDriver identifies a file rotation implementation strategy.
+type RotationDriver string
+
+const (
+	RotationDriverLumberjack RotationDriver = "lumberjack"
+	RotationDriverExternal   RotationDriver = "external"
+	RotationDriverLogrotate  RotationDriver = "logrotate"
+	RotationDriverNone       RotationDriver = "none"
+)
+
+// IsValid reports whether d is a supported rotation driver.
+func (d RotationDriver) IsValid() bool {
+	switch d {
+	case RotationDriverLumberjack, RotationDriverExternal, RotationDriverLogrotate, RotationDriverNone:
+		return true
+	default:
+		return false
+	}
+}
+
+// OTLPProtocol identifies an OTLP exporter protocol.
+type OTLPProtocol string
+
+const (
+	OTLPProtocolGRPC OTLPProtocol = "grpc"
+	OTLPProtocolHTTP OTLPProtocol = "http"
+)
+
+// IsValid reports whether p is a supported OTLP protocol.
+func (p OTLPProtocol) IsValid() bool {
+	switch p {
+	case OTLPProtocolGRPC, OTLPProtocolHTTP:
+		return true
+	default:
+		return false
+	}
+}
+
+// TraceSamplerType identifies an OpenTelemetry trace sampler shape.
+type TraceSamplerType string
+
+const (
+	TraceSamplerAlwaysOn                TraceSamplerType = "always_on"
+	TraceSamplerAlwaysOff               TraceSamplerType = "always_off"
+	TraceSamplerTraceIDRatio            TraceSamplerType = "traceidratio"
+	TraceSamplerParentBasedTraceIDRatio TraceSamplerType = "parentbased_traceidratio"
+)
+
+// IsValid reports whether t is a supported trace sampler type.
+func (t TraceSamplerType) IsValid() bool {
+	switch t {
+	case TraceSamplerAlwaysOn, TraceSamplerAlwaysOff, TraceSamplerTraceIDRatio, TraceSamplerParentBasedTraceIDRatio:
+		return true
+	default:
+		return false
+	}
+}
+
+// Config is the shared logging configuration contract.
+type Config struct {
+	Level       Level               `json:"level" yaml:"level" mapstructure:"level"`
+	Development bool                `json:"development" yaml:"development" mapstructure:"development"`
+	Resource    ResourceConfig      `json:"resource" yaml:"resource" mapstructure:"resource"`
+	Zap         ZapConfig           `json:"zap" yaml:"zap" mapstructure:"zap"`
+	Cores       []CoreConfig        `json:"cores" yaml:"cores" mapstructure:"cores"`
+	Buffering   BufferingConfig     `json:"buffering" yaml:"buffering" mapstructure:"buffering"`
+	Shutdown    ShutdownConfig      `json:"shutdown" yaml:"shutdown" mapstructure:"shutdown"`
+	Redaction   RedactionConfig     `json:"redaction" yaml:"redaction" mapstructure:"redaction"`
+	OTel        OpenTelemetryConfig `json:"otel" yaml:"otel" mapstructure:"otel"`
+}
+
+// ResourceConfig carries logging-specific resource overrides.
+type ResourceConfig struct {
+	ServiceVersion string `json:"service_version" yaml:"service_version" mapstructure:"service_version"`
+}
+
+// ZapConfig mirrors the zap.Config shape without importing zap.
+type ZapConfig struct {
+	Level               Level          `json:"level" yaml:"level" mapstructure:"level"`
+	Development         bool           `json:"development" yaml:"development" mapstructure:"development"`
+	DisableCaller       bool           `json:"disable_caller" yaml:"disable_caller" mapstructure:"disable_caller"`
+	DisableStacktrace   bool           `json:"disable_stacktrace" yaml:"disable_stacktrace" mapstructure:"disable_stacktrace"`
+	DisableErrorVerbose bool           `json:"disable_error_verbose" yaml:"disable_error_verbose" mapstructure:"disable_error_verbose"`
+	Encoding            Encoding       `json:"encoding" yaml:"encoding" mapstructure:"encoding"`
+	EncoderConfig       EncoderConfig  `json:"encoder_config" yaml:"encoder_config" mapstructure:"encoder_config"`
+	OutputPaths         []string       `json:"output_paths" yaml:"output_paths" mapstructure:"output_paths"`
+	ErrorOutputPaths    []string       `json:"error_output_paths" yaml:"error_output_paths" mapstructure:"error_output_paths"`
+	InitialFields       map[string]any `json:"initial_fields" yaml:"initial_fields" mapstructure:"initial_fields"`
+	Sampling            SamplingConfig `json:"sampling" yaml:"sampling" mapstructure:"sampling"`
+}
+
+// EncoderConfig mirrors the zapcore.EncoderConfig shape with symbolic encoders.
+type EncoderConfig struct {
+	MessageKey       string `json:"message_key" yaml:"message_key" mapstructure:"message_key"`
+	LevelKey         string `json:"level_key" yaml:"level_key" mapstructure:"level_key"`
+	TimeKey          string `json:"time_key" yaml:"time_key" mapstructure:"time_key"`
+	NameKey          string `json:"name_key" yaml:"name_key" mapstructure:"name_key"`
+	CallerKey        string `json:"caller_key" yaml:"caller_key" mapstructure:"caller_key"`
+	FunctionKey      string `json:"function_key" yaml:"function_key" mapstructure:"function_key"`
+	StacktraceKey    string `json:"stacktrace_key" yaml:"stacktrace_key" mapstructure:"stacktrace_key"`
+	SkipLineEnding   bool   `json:"skip_line_ending" yaml:"skip_line_ending" mapstructure:"skip_line_ending"`
+	LineEnding       string `json:"line_ending" yaml:"line_ending" mapstructure:"line_ending"`
+	LevelEncoder     string `json:"level_encoder" yaml:"level_encoder" mapstructure:"level_encoder"`
+	TimeEncoder      string `json:"time_encoder" yaml:"time_encoder" mapstructure:"time_encoder"`
+	DurationEncoder  string `json:"duration_encoder" yaml:"duration_encoder" mapstructure:"duration_encoder"`
+	CallerEncoder    string `json:"caller_encoder" yaml:"caller_encoder" mapstructure:"caller_encoder"`
+	NameEncoder      string `json:"name_encoder" yaml:"name_encoder" mapstructure:"name_encoder"`
+	ConsoleSeparator string `json:"console_separator" yaml:"console_separator" mapstructure:"console_separator"`
+}
+
+// SamplingConfig mirrors zap sampling configuration without importing zap.
+type SamplingConfig struct {
+	Enabled     bool `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	Initial     int  `json:"initial" yaml:"initial" mapstructure:"initial"`
+	Thereafter  int  `json:"thereafter" yaml:"thereafter" mapstructure:"thereafter"`
+	HookMetrics bool `json:"hook_metrics" yaml:"hook_metrics" mapstructure:"hook_metrics"`
+}
+
+// CoreConfig declares one future zapcore output core.
+type CoreConfig struct {
+	Name        string         `json:"name" yaml:"name" mapstructure:"name"`
+	Enabled     bool           `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	Type        CoreType       `json:"type" yaml:"type" mapstructure:"type"`
+	Level       Level          `json:"level" yaml:"level" mapstructure:"level"`
+	Encoding    Encoding       `json:"encoding" yaml:"encoding" mapstructure:"encoding"`
+	OutputPaths []string       `json:"output_paths" yaml:"output_paths" mapstructure:"output_paths"`
+	Datasets    []string       `json:"datasets" yaml:"datasets" mapstructure:"datasets"`
+	Rotation    RotationConfig `json:"rotation" yaml:"rotation" mapstructure:"rotation"`
+}
+
+// RotationConfig declares a future file rotation mapping.
+type RotationConfig struct {
+	Driver     RotationDriver `json:"driver" yaml:"driver" mapstructure:"driver"`
+	Enabled    bool           `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	MaxSizeMB  int            `json:"max_size_mb" yaml:"max_size_mb" mapstructure:"max_size_mb"`
+	MaxBackups int            `json:"max_backups" yaml:"max_backups" mapstructure:"max_backups"`
+	MaxAgeDays int            `json:"max_age_days" yaml:"max_age_days" mapstructure:"max_age_days"`
+	Compress   bool           `json:"compress" yaml:"compress" mapstructure:"compress"`
+	LocalTime  bool           `json:"local_time" yaml:"local_time" mapstructure:"local_time"`
+}
+
+// BufferingConfig declares future buffered writer behavior.
+type BufferingConfig struct {
+	Enabled       bool          `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	SizeBytes     int           `json:"size_bytes" yaml:"size_bytes" mapstructure:"size_bytes"`
+	FlushInterval time.Duration `json:"flush_interval" yaml:"flush_interval" mapstructure:"flush_interval"`
+}
+
+// ShutdownConfig declares logging shutdown behavior.
+type ShutdownConfig struct {
+	Timeout time.Duration `json:"timeout" yaml:"timeout" mapstructure:"timeout"`
+}
+
+// RedactionConfig declares sensitive key replacement policy.
+type RedactionConfig struct {
+	Enabled     bool     `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	Replacement string   `json:"replacement" yaml:"replacement" mapstructure:"replacement"`
+	Keys        []string `json:"keys" yaml:"keys" mapstructure:"keys"`
+}
+
+// OpenTelemetryConfig declares future OpenTelemetry SDK integration settings.
+type OpenTelemetryConfig struct {
+	Enabled     bool                     `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	Propagation OpenTelemetryPropagation `json:"propagation" yaml:"propagation" mapstructure:"propagation"`
+	Traces      OpenTelemetryTraces      `json:"traces" yaml:"traces" mapstructure:"traces"`
+	Metrics     OpenTelemetrySignal      `json:"metrics" yaml:"metrics" mapstructure:"metrics"`
+	Logs        OpenTelemetrySignal      `json:"logs" yaml:"logs" mapstructure:"logs"`
+	Exporter    OpenTelemetryExporter    `json:"exporter" yaml:"exporter" mapstructure:"exporter"`
+	Batch       OpenTelemetryBatch       `json:"batch" yaml:"batch" mapstructure:"batch"`
+}
+
+// OpenTelemetryPropagation declares propagation settings.
+type OpenTelemetryPropagation struct {
+	TraceContext bool `json:"trace_context" yaml:"trace_context" mapstructure:"trace_context"`
+	Baggage      bool `json:"baggage" yaml:"baggage" mapstructure:"baggage"`
+}
+
+// OpenTelemetryTraces declares trace settings.
+type OpenTelemetryTraces struct {
+	Enabled bool               `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	Sampler TraceSamplerConfig `json:"sampler" yaml:"sampler" mapstructure:"sampler"`
+}
+
+// TraceSamplerConfig declares trace sampler settings.
+type TraceSamplerConfig struct {
+	Type  TraceSamplerType `json:"type" yaml:"type" mapstructure:"type"`
+	Ratio float64          `json:"ratio" yaml:"ratio" mapstructure:"ratio"`
+}
+
+// OpenTelemetrySignal declares a simple OpenTelemetry signal toggle.
+type OpenTelemetrySignal struct {
+	Enabled bool `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+}
+
+// OpenTelemetryExporter declares exporter settings.
+type OpenTelemetryExporter struct {
+	OTLP OTLPExporterConfig `json:"otlp" yaml:"otlp" mapstructure:"otlp"`
+}
+
+// OTLPExporterConfig declares future OTLP exporter settings.
+type OTLPExporterConfig struct {
+	Enabled     bool              `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	Endpoint    string            `json:"endpoint" yaml:"endpoint" mapstructure:"endpoint"`
+	Protocol    OTLPProtocol      `json:"protocol" yaml:"protocol" mapstructure:"protocol"`
+	Insecure    bool              `json:"insecure" yaml:"insecure" mapstructure:"insecure"`
+	Headers     map[string]string `json:"headers" yaml:"headers" mapstructure:"headers"`
+	Compression string            `json:"compression" yaml:"compression" mapstructure:"compression"`
+	Timeout     time.Duration     `json:"timeout" yaml:"timeout" mapstructure:"timeout"`
+}
+
+// OpenTelemetryBatch declares batch processor settings.
+type OpenTelemetryBatch struct {
+	MaxQueueSize       int           `json:"max_queue_size" yaml:"max_queue_size" mapstructure:"max_queue_size"`
+	ScheduleDelay      time.Duration `json:"schedule_delay" yaml:"schedule_delay" mapstructure:"schedule_delay"`
+	ExportTimeout      time.Duration `json:"export_timeout" yaml:"export_timeout" mapstructure:"export_timeout"`
+	MaxExportBatchSize int           `json:"max_export_batch_size" yaml:"max_export_batch_size" mapstructure:"max_export_batch_size"`
+}
+
+// Default fills stable shared logging defaults.
+func (c *Config) Default() error {
+	if c == nil {
+		return errors.New("logging: config must not be nil")
+	}
+	if c.Level == "" {
+		c.Level = LevelInfo
+	}
+	c.Zap.Default(c.Level, c.Development)
+	if len(c.Cores) == 0 {
+		c.Cores = []CoreConfig{
+			defaultConsoleCore(c.Level),
+			defaultServiceFileCore(c.Level),
+		}
+	} else {
+		for index := range c.Cores {
+			c.Cores[index].Default(c.Level)
+		}
+	}
+	c.Buffering.Default()
+	c.Shutdown.Default()
+	c.Redaction.Default()
+	c.OTel.Default()
+	return nil
+}
+
+// Default fills zap-facing defaults.
+func (c *ZapConfig) Default(level Level, development bool) {
+	if c.Level == "" {
+		c.Level = level
+	}
+	c.Development = c.Development || development
+	if c.Encoding == "" {
+		c.Encoding = EncodingJSON
+	}
+	c.EncoderConfig.Default()
+	if len(c.OutputPaths) == 0 {
+		c.OutputPaths = []string{"stdout"}
+	}
+	if len(c.ErrorOutputPaths) == 0 {
+		c.ErrorOutputPaths = []string{"stderr"}
+	}
+	if c.InitialFields == nil {
+		c.InitialFields = map[string]any{}
+	}
+	c.Sampling.Default()
+}
+
+// Default fills encoder defaults.
+func (c *EncoderConfig) Default() {
+	if c.MessageKey == "" {
+		c.MessageKey = "message"
+	}
+	if c.LevelKey == "" {
+		c.LevelKey = "severity_text"
+	}
+	if c.TimeKey == "" {
+		c.TimeKey = "timestamp"
+	}
+	if c.NameKey == "" {
+		c.NameKey = "logger"
+	}
+	if c.CallerKey == "" {
+		c.CallerKey = "caller"
+	}
+	if c.FunctionKey == "" {
+		c.FunctionKey = "function"
+	}
+	if c.StacktraceKey == "" {
+		c.StacktraceKey = "stacktrace"
+	}
+	if c.LineEnding == "" {
+		c.LineEnding = "\n"
+	}
+	if c.LevelEncoder == "" {
+		c.LevelEncoder = "capital"
+	}
+	if c.TimeEncoder == "" {
+		c.TimeEncoder = "rfc3339nano"
+	}
+	if c.DurationEncoder == "" {
+		c.DurationEncoder = "millis"
+	}
+	if c.CallerEncoder == "" {
+		c.CallerEncoder = "short"
+	}
+	if c.NameEncoder == "" {
+		c.NameEncoder = "full"
+	}
+	if c.ConsoleSeparator == "" {
+		c.ConsoleSeparator = "\t"
+	}
+}
+
+// Default fills sampling defaults without enabling sampling by itself.
+func (c *SamplingConfig) Default() {
+	if c.Initial == 0 {
+		c.Initial = 100
+	}
+	if c.Thereafter == 0 {
+		c.Thereafter = 100
+	}
+}
+
+// Default fills core defaults.
+func (c *CoreConfig) Default(level Level) {
+	if c.Level == "" {
+		c.Level = level
+	}
+	if c.Type == CoreTypeConsole {
+		if c.Encoding == "" {
+			c.Encoding = EncodingConsole
+		}
+		if len(c.OutputPaths) == 0 {
+			c.OutputPaths = []string{"stdout"}
+		}
+	}
+	if c.Type == CoreTypeFile {
+		if c.Encoding == "" {
+			c.Encoding = EncodingJSON
+		}
+		if len(c.OutputPaths) == 0 {
+			c.OutputPaths = []string{DefaultFilePathTemplate}
+		}
+		c.Rotation.Default()
+	}
+	if len(c.Datasets) == 0 {
+		c.Datasets = []string{"*"}
+	}
+}
+
+// Default fills rotation defaults.
+func (c *RotationConfig) Default() {
+	if c.Driver == "" {
+		c.Driver = RotationDriverLumberjack
+	}
+	if c.Driver == RotationDriverLumberjack {
+		if c.MaxSizeMB == 0 {
+			c.MaxSizeMB = 100
+		}
+		if c.MaxBackups == 0 {
+			c.MaxBackups = 10
+		}
+		if c.MaxAgeDays == 0 {
+			c.MaxAgeDays = 14
+		}
+		c.Compress = true
+		c.LocalTime = true
+	}
+	if c.Driver != RotationDriverNone {
+		c.Enabled = true
+	}
+}
+
+// Default fills buffering defaults.
+func (c *BufferingConfig) Default() {
+	if c.SizeBytes == 0 {
+		c.SizeBytes = 262144
+	}
+	if c.FlushInterval == 0 {
+		c.FlushInterval = time.Second
+	}
+	c.Enabled = true
+}
+
+// Default fills shutdown defaults.
+func (c *ShutdownConfig) Default() {
+	if c.Timeout == 0 {
+		c.Timeout = 5 * time.Second
+	}
+}
+
+// Default fills redaction defaults.
+func (c *RedactionConfig) Default() {
+	c.Enabled = true
+	if c.Replacement == "" {
+		c.Replacement = DefaultRedactionReplacement
+	}
+	if len(c.Keys) == 0 {
+		c.Keys = DefaultRedactionKeys()
+	}
+}
+
+// Default fills OpenTelemetry configuration defaults.
+func (c *OpenTelemetryConfig) Default() {
+	c.Enabled = true
+	c.Propagation.Default()
+	c.Traces.Default()
+	c.Metrics.Enabled = true
+	c.Logs.Enabled = true
+	c.Exporter.Default()
+	c.Batch.Default()
+}
+
+// Default fills OpenTelemetry propagation defaults.
+func (c *OpenTelemetryPropagation) Default() {
+	c.TraceContext = true
+	c.Baggage = true
+}
+
+// Default fills OpenTelemetry trace defaults.
+func (c *OpenTelemetryTraces) Default() {
+	c.Enabled = true
+	c.Sampler.Default()
+}
+
+// Default fills trace sampler defaults.
+func (c *TraceSamplerConfig) Default() {
+	if c.Type == "" {
+		c.Type = TraceSamplerParentBasedTraceIDRatio
+	}
+	if c.Ratio == 0 {
+		c.Ratio = 1
+	}
+}
+
+// Default fills exporter defaults.
+func (c *OpenTelemetryExporter) Default() {
+	c.OTLP.Default()
+}
+
+// Default fills OTLP exporter defaults.
+func (c *OTLPExporterConfig) Default() {
+	if c.Endpoint == "" {
+		c.Endpoint = "localhost:4317"
+	}
+	if c.Protocol == "" {
+		c.Protocol = OTLPProtocolGRPC
+	}
+	c.Insecure = true
+	if c.Headers == nil {
+		c.Headers = map[string]string{}
+	}
+	if c.Compression == "" {
+		c.Compression = "gzip"
+	}
+	if c.Timeout == 0 {
+		c.Timeout = 10 * time.Second
+	}
+}
+
+// Default fills OpenTelemetry batch defaults.
+func (c *OpenTelemetryBatch) Default() {
+	if c.MaxQueueSize == 0 {
+		c.MaxQueueSize = 2048
+	}
+	if c.ScheduleDelay == 0 {
+		c.ScheduleDelay = 5 * time.Second
+	}
+	if c.ExportTimeout == 0 {
+		c.ExportTimeout = 30 * time.Second
+	}
+	if c.MaxExportBatchSize == 0 {
+		c.MaxExportBatchSize = 512
+	}
+}
+
+// DefaultRedactionKeys returns the default sensitive key list.
+func DefaultRedactionKeys() []string {
+	return []string{
+		"authorization",
+		"cookie",
+		"set-cookie",
+		"token",
+		"access_token",
+		"refresh_token",
+		"password",
+		"passwd",
+		"secret",
+		"private_key",
+		"credential",
+		"api_key",
+		"client_secret",
+		"session",
+	}
+}
+
+func defaultConsoleCore(level Level) CoreConfig {
+	return CoreConfig{
+		Name:        "console",
+		Enabled:     true,
+		Type:        CoreTypeConsole,
+		Level:       level,
+		Encoding:    EncodingConsole,
+		OutputPaths: []string{"stdout"},
+		Datasets:    []string{"*"},
+	}
+}
+
+func defaultServiceFileCore(level Level) CoreConfig {
+	return CoreConfig{
+		Name:        "service-file",
+		Enabled:     true,
+		Type:        CoreTypeFile,
+		Level:       level,
+		Encoding:    EncodingJSON,
+		OutputPaths: []string{DefaultFilePathTemplate},
+		Datasets:    []string{"*"},
+		Rotation: RotationConfig{
+			Driver:     RotationDriverLumberjack,
+			Enabled:    true,
+			MaxSizeMB:  100,
+			MaxBackups: 10,
+			MaxAgeDays: 14,
+			Compress:   true,
+			LocalTime:  true,
+		},
+	}
+}

--- a/packages/shared/logging/config_test.go
+++ b/packages/shared/logging/config_test.go
@@ -90,8 +90,6 @@ func TestFieldNameConstants(t *testing.T) {
 	assertEqual(t, FieldCorrelationID, "correlation_id")
 	assertEqual(t, FieldEventName, "event.name")
 	assertEqual(t, FieldEventDataset, "event.dataset")
-	assertEqual(t, FieldEDAEventType, "eda.event_type")
-	assertEqual(t, FieldEDACausationID, "eda.causation_id")
 	assertEqual(t, FieldComponent, "component")
 	assertEqual(t, FieldOperation, "operation")
 	assertEqual(t, FieldTags, "tags")
@@ -429,28 +427,18 @@ func TestConfigJSONAndYAMLTags(t *testing.T) {
 	}
 }
 
-func TestModelTypesKeepObservabilityAndEDAEventsSeparate(t *testing.T) {
+func TestModelTypesRepresentObservabilityEvents(t *testing.T) {
 	event := Event{
-		Name:     "eda.event.published",
-		Dataset:  "dox.iam.eda",
-		Category: "messaging",
-		Action:   "publish",
-		Outcome:  "success",
-	}
-	eda := EDAEvent{
-		EventID:       "evt_001",
-		EventType:     "iam.login.failed",
-		CausationID:   "req_001",
-		CorrelationID: "corr_001",
-		MessageID:     "msg_001",
-		Topic:         "iam.login",
+		Name:     "iam.login.rejected",
+		Dataset:  "dox.iam.security",
+		Category: "authentication",
+		Type:     "denied",
+		Action:   "login",
+		Outcome:  "failure",
 	}
 
-	if event.Name != "eda.event.published" {
-		t.Fatalf("expected observability event name to describe publish action, got %q", event.Name)
-	}
-	if eda.EventType != "iam.login.failed" {
-		t.Fatalf("expected EDA event type to describe domain event, got %q", eda.EventType)
+	if event.Name != "iam.login.rejected" || event.Dataset != "dox.iam.security" {
+		t.Fatalf("expected observability event to describe the log record, got %+v", event)
 	}
 }
 

--- a/packages/shared/logging/config_test.go
+++ b/packages/shared/logging/config_test.go
@@ -1,0 +1,336 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : config_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-26
+ * @Modified: 2026-04-26
+ */
+
+package logging
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	sharedconfig "github.com/opendox/dox/packages/shared/config"
+	"go.yaml.in/yaml/v3"
+)
+
+func TestConfigDefaultAppliesSharedContract(t *testing.T) {
+	cfg := Config{}
+
+	if err := cfg.Default(); err != nil {
+		t.Fatalf("default config: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate default config: %v", err)
+	}
+
+	if cfg.Level != LevelInfo {
+		t.Fatalf("expected root level info, got %q", cfg.Level)
+	}
+	if cfg.Zap.Encoding != EncodingJSON {
+		t.Fatalf("expected zap encoding json, got %q", cfg.Zap.Encoding)
+	}
+	if cfg.Zap.EncoderConfig.MessageKey != "message" {
+		t.Fatalf("expected message key default, got %q", cfg.Zap.EncoderConfig.MessageKey)
+	}
+	if len(cfg.Cores) != 2 {
+		t.Fatalf("expected two default cores, got %d", len(cfg.Cores))
+	}
+	assertCore(t, cfg.Cores[0], "console", CoreTypeConsole, EncodingConsole, []string{"stdout"})
+	assertCore(t, cfg.Cores[1], "service-file", CoreTypeFile, EncodingJSON, []string{DefaultFilePathTemplate})
+	if cfg.Cores[1].Rotation.Driver != RotationDriverLumberjack {
+		t.Fatalf("expected lumberjack rotation, got %q", cfg.Cores[1].Rotation.Driver)
+	}
+	if cfg.Buffering.FlushInterval != time.Second {
+		t.Fatalf("expected buffering flush interval 1s, got %s", cfg.Buffering.FlushInterval)
+	}
+	if cfg.Shutdown.Timeout != 5*time.Second {
+		t.Fatalf("expected shutdown timeout 5s, got %s", cfg.Shutdown.Timeout)
+	}
+	if !cfg.Redaction.Enabled || cfg.Redaction.Replacement != DefaultRedactionReplacement {
+		t.Fatalf("expected redaction defaults, got %+v", cfg.Redaction)
+	}
+	if !contains(cfg.Redaction.Keys, "authorization") || !contains(cfg.Redaction.Keys, "client_secret") {
+		t.Fatalf("expected sensitive redaction keys, got %#v", cfg.Redaction.Keys)
+	}
+	if !cfg.OTel.Propagation.TraceContext || !cfg.OTel.Propagation.Baggage {
+		t.Fatalf("expected OpenTelemetry propagation defaults, got %+v", cfg.OTel.Propagation)
+	}
+	if cfg.OTel.Exporter.OTLP.Enabled {
+		t.Fatal("expected OTLP exporter to be disabled by default")
+	}
+}
+
+func TestFieldNameConstants(t *testing.T) {
+	assertEqual(t, FieldServiceName, "service.name")
+	assertEqual(t, FieldServiceInstanceID, "service.instance.id")
+	assertEqual(t, FieldDeploymentEnvironmentName, "deployment.environment.name")
+	assertEqual(t, FieldTraceID, "trace_id")
+	assertEqual(t, FieldCorrelationID, "correlation_id")
+	assertEqual(t, FieldEventName, "event.name")
+	assertEqual(t, FieldEventDataset, "event.dataset")
+	assertEqual(t, FieldEDAEventType, "eda.event_type")
+	assertEqual(t, FieldEDACausationID, "eda.causation_id")
+	assertEqual(t, FieldComponent, "component")
+	assertEqual(t, FieldOperation, "operation")
+	assertEqual(t, FieldTags, "tags")
+	assertEqual(t, FieldFields, "fields")
+}
+
+func TestConfigValidateRejectsInvalidValues(t *testing.T) {
+	cfg := Config{}
+	if err := cfg.Default(); err != nil {
+		t.Fatalf("default config: %v", err)
+	}
+
+	cfg.Level = Level("verbose")
+	cfg.Zap.Encoding = Encoding("plain")
+	cfg.Zap.EncoderConfig.TimeEncoder = "clock"
+	cfg.Cores[0].Name = cfg.Cores[1].Name
+	cfg.Cores[0].Datasets = []string{""}
+	cfg.Cores[1].Rotation.MaxSizeMB = 0
+	cfg.Buffering.SizeBytes = 0
+	cfg.Shutdown.Timeout = 0
+	cfg.Redaction.Keys = []string{""}
+	cfg.OTel.Exporter.OTLP.Enabled = true
+	cfg.OTel.Exporter.OTLP.Endpoint = ""
+	cfg.OTel.Traces.Sampler.Ratio = 2
+
+	err := cfg.Validate()
+	for _, field := range []string{
+		"level",
+		"zap.encoding",
+		"zap.encoder_config.time_encoder",
+		"cores[1].name",
+		"cores[0].datasets[0]",
+		"cores[1].rotation.max_size_mb",
+		"buffering.size_bytes",
+		"shutdown.timeout",
+		"redaction.keys[0]",
+		"otel.exporter.otlp.endpoint",
+		"otel.traces.sampler.ratio",
+	} {
+		if !hasValidationField(err, field) {
+			t.Fatalf("expected validation field %s, got %v", field, err)
+		}
+	}
+}
+
+func TestConfigDecodesWithMapstructure(t *testing.T) {
+	var cfg Config
+
+	err := sharedconfig.DecodeValues(context.Background(), map[string]any{
+		"level": "debug",
+		"zap": map[string]any{
+			"level":    "warn",
+			"encoding": "json",
+			"encoder_config": map[string]any{
+				"message_key":      "msg",
+				"level_encoder":    "lowercase",
+				"time_encoder":     "iso8601",
+				"duration_encoder": "seconds",
+				"caller_encoder":   "full",
+				"name_encoder":     "full",
+			},
+			"output_paths":       []any{"stdout"},
+			"error_output_paths": []any{"stderr"},
+		},
+		"cores": []any{
+			map[string]any{
+				"name":         "console",
+				"enabled":      true,
+				"type":         "console",
+				"level":        "debug",
+				"encoding":     "console",
+				"output_paths": []any{"stdout"},
+				"datasets":     []any{"*"},
+			},
+		},
+		"buffering": map[string]any{
+			"enabled":        true,
+			"size_bytes":     4096,
+			"flush_interval": "2s",
+		},
+		"shutdown": map[string]any{
+			"timeout": "3s",
+		},
+		"redaction": map[string]any{
+			"enabled":     true,
+			"replacement": "[redacted]",
+			"keys":        []any{"token"},
+		},
+		"otel": map[string]any{
+			"enabled": true,
+			"propagation": map[string]any{
+				"trace_context": true,
+				"baggage":       true,
+			},
+			"traces": map[string]any{
+				"enabled": true,
+				"sampler": map[string]any{
+					"type":  "traceidratio",
+					"ratio": 0.5,
+				},
+			},
+			"metrics": map[string]any{"enabled": true},
+			"logs":    map[string]any{"enabled": true},
+			"exporter": map[string]any{
+				"otlp": map[string]any{
+					"enabled":  false,
+					"endpoint": "collector:4317",
+					"protocol": "grpc",
+					"timeout":  "5s",
+				},
+			},
+			"batch": map[string]any{
+				"max_queue_size":        64,
+				"schedule_delay":        "1s",
+				"export_timeout":        "2s",
+				"max_export_batch_size": 16,
+			},
+		},
+	}, &cfg, sharedconfig.Options{})
+	if err != nil {
+		t.Fatalf("decode logging config: %v", err)
+	}
+	if cfg.Level != LevelDebug {
+		t.Fatalf("expected decoded level debug, got %q", cfg.Level)
+	}
+	if cfg.Zap.EncoderConfig.MessageKey != "msg" {
+		t.Fatalf("expected decoded message key msg, got %q", cfg.Zap.EncoderConfig.MessageKey)
+	}
+	if cfg.Buffering.FlushInterval != 2*time.Second {
+		t.Fatalf("expected decoded buffering duration, got %s", cfg.Buffering.FlushInterval)
+	}
+	if cfg.OTel.Traces.Sampler.Ratio != 0.5 {
+		t.Fatalf("expected decoded sampler ratio 0.5, got %f", cfg.OTel.Traces.Sampler.Ratio)
+	}
+}
+
+func TestConfigJSONAndYAMLTags(t *testing.T) {
+	cfg := Config{}
+	if err := cfg.Default(); err != nil {
+		t.Fatalf("default config: %v", err)
+	}
+
+	jsonBytes, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+	jsonText := string(jsonBytes)
+	for _, item := range []string{`"encoder_config"`, `"output_paths"`, `"error_output_paths"`, `"max_size_mb"`} {
+		if !strings.Contains(jsonText, item) {
+			t.Fatalf("expected JSON to contain %s, got %s", item, jsonText)
+		}
+	}
+
+	yamlBytes, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal yaml: %v", err)
+	}
+	yamlText := string(yamlBytes)
+	for _, item := range []string{"encoder_config:", "output_paths:", "error_output_paths:", "max_size_mb:"} {
+		if !strings.Contains(yamlText, item) {
+			t.Fatalf("expected YAML to contain %s, got %s", item, yamlText)
+		}
+	}
+}
+
+func TestModelTypesKeepObservabilityAndEDAEventsSeparate(t *testing.T) {
+	event := Event{
+		Name:     "eda.event.published",
+		Dataset:  "dox.iam.eda",
+		Category: "messaging",
+		Action:   "publish",
+		Outcome:  "success",
+	}
+	eda := EDAEvent{
+		EventID:       "evt_001",
+		EventType:     "iam.login.failed",
+		CausationID:   "req_001",
+		CorrelationID: "corr_001",
+		MessageID:     "msg_001",
+		Topic:         "iam.login",
+	}
+
+	if event.Name != "eda.event.published" {
+		t.Fatalf("expected observability event name to describe publish action, got %q", event.Name)
+	}
+	if eda.EventType != "iam.login.failed" {
+		t.Fatalf("expected EDA event type to describe domain event, got %q", eda.EventType)
+	}
+}
+
+func assertCore(t *testing.T, core CoreConfig, name string, coreType CoreType, encoding Encoding, outputPaths []string) {
+	t.Helper()
+	if core.Name != name {
+		t.Fatalf("expected core name %q, got %q", name, core.Name)
+	}
+	if !core.Enabled {
+		t.Fatalf("expected core %q to be enabled", name)
+	}
+	if core.Type != coreType {
+		t.Fatalf("expected core %q type %q, got %q", name, coreType, core.Type)
+	}
+	if core.Encoding != encoding {
+		t.Fatalf("expected core %q encoding %q, got %q", name, encoding, core.Encoding)
+	}
+	if len(core.OutputPaths) != len(outputPaths) {
+		t.Fatalf("expected core %q output paths %#v, got %#v", name, outputPaths, core.OutputPaths)
+	}
+	for index, expected := range outputPaths {
+		if core.OutputPaths[index] != expected {
+			t.Fatalf("expected core %q output path %d to be %q, got %q", name, index, expected, core.OutputPaths[index])
+		}
+	}
+}
+
+func assertEqual(t *testing.T, got string, expected string) {
+	t.Helper()
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func contains(items []string, expected string) bool {
+	for _, item := range items {
+		if item == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func hasValidationField(err error, field string) bool {
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) {
+		return false
+	}
+	for _, item := range validationErr.Fields {
+		if item.Field == field {
+			return true
+		}
+	}
+	return false
+}

--- a/packages/shared/logging/config_test.go
+++ b/packages/shared/logging/config_test.go
@@ -68,13 +68,13 @@ func TestConfigDefaultAppliesSharedContract(t *testing.T) {
 	if cfg.Shutdown.Timeout != 5*time.Second {
 		t.Fatalf("expected shutdown timeout 5s, got %s", cfg.Shutdown.Timeout)
 	}
-	if !cfg.Redaction.Enabled || cfg.Redaction.Replacement != DefaultRedactionReplacement {
+	if !boolValue(cfg.Redaction.Enabled) || cfg.Redaction.Replacement != DefaultRedactionReplacement {
 		t.Fatalf("expected redaction defaults, got %+v", cfg.Redaction)
 	}
 	if !contains(cfg.Redaction.Keys, "authorization") || !contains(cfg.Redaction.Keys, "client_secret") {
 		t.Fatalf("expected sensitive redaction keys, got %#v", cfg.Redaction.Keys)
 	}
-	if !cfg.OTel.Propagation.TraceContext || !cfg.OTel.Propagation.Baggage {
+	if !boolValue(cfg.OTel.Propagation.TraceContext) || !boolValue(cfg.OTel.Propagation.Baggage) {
 		t.Fatalf("expected OpenTelemetry propagation defaults, got %+v", cfg.OTel.Propagation)
 	}
 	if cfg.OTel.Exporter.OTLP.Enabled {
@@ -96,6 +96,92 @@ func TestFieldNameConstants(t *testing.T) {
 	assertEqual(t, FieldOperation, "operation")
 	assertEqual(t, FieldTags, "tags")
 	assertEqual(t, FieldFields, "fields")
+}
+
+func TestConfigDefaultPreservesExplicitDisabledToggles(t *testing.T) {
+	cfg := Config{
+		Cores: []CoreConfig{
+			{
+				Name:        "console",
+				Enabled:     boolPtr(false),
+				Type:        CoreTypeConsole,
+				Level:       LevelInfo,
+				Encoding:    EncodingConsole,
+				OutputPaths: []string{"stdout"},
+				Datasets:    []string{"*"},
+			},
+			{
+				Name:        "service-file",
+				Enabled:     boolPtr(false),
+				Type:        CoreTypeFile,
+				Level:       LevelInfo,
+				Encoding:    EncodingJSON,
+				OutputPaths: []string{DefaultFilePathTemplate},
+				Datasets:    []string{"*"},
+				Rotation: RotationConfig{
+					Enabled:   boolPtr(false),
+					Compress:  boolPtr(false),
+					LocalTime: boolPtr(false),
+				},
+			},
+		},
+		Buffering: BufferingConfig{
+			Enabled: boolPtr(false),
+		},
+		Redaction: RedactionConfig{
+			Enabled: boolPtr(false),
+		},
+		OTel: OpenTelemetryConfig{
+			Enabled: boolPtr(false),
+			Propagation: OpenTelemetryPropagation{
+				TraceContext: boolPtr(false),
+				Baggage:      boolPtr(false),
+			},
+			Traces: OpenTelemetryTraces{
+				Enabled: boolPtr(false),
+			},
+			Metrics: OpenTelemetrySignal{
+				Enabled: boolPtr(false),
+			},
+			Logs: OpenTelemetrySignal{
+				Enabled: boolPtr(false),
+			},
+			Exporter: OpenTelemetryExporter{
+				OTLP: OTLPExporterConfig{
+					Insecure: boolPtr(false),
+				},
+			},
+		},
+	}
+
+	if err := cfg.Default(); err != nil {
+		t.Fatalf("default config: %v", err)
+	}
+
+	if boolValue(cfg.Cores[0].Enabled) || boolValue(cfg.Cores[1].Enabled) {
+		t.Fatalf("expected explicit disabled cores to stay disabled, got %+v", cfg.Cores)
+	}
+	if boolValue(cfg.Cores[1].Rotation.Enabled) {
+		t.Fatalf("expected explicit disabled rotation to stay disabled, got %+v", cfg.Cores[1].Rotation)
+	}
+	if boolValue(cfg.Cores[1].Rotation.Compress) || boolValue(cfg.Cores[1].Rotation.LocalTime) {
+		t.Fatalf("expected explicit disabled rotation options to stay disabled, got %+v", cfg.Cores[1].Rotation)
+	}
+	if boolValue(cfg.Buffering.Enabled) {
+		t.Fatalf("expected explicit disabled buffering to stay disabled, got %+v", cfg.Buffering)
+	}
+	if boolValue(cfg.Redaction.Enabled) {
+		t.Fatalf("expected explicit disabled redaction to stay disabled, got %+v", cfg.Redaction)
+	}
+	if boolValue(cfg.OTel.Enabled) ||
+		boolValue(cfg.OTel.Propagation.TraceContext) ||
+		boolValue(cfg.OTel.Propagation.Baggage) ||
+		boolValue(cfg.OTel.Traces.Enabled) ||
+		boolValue(cfg.OTel.Metrics.Enabled) ||
+		boolValue(cfg.OTel.Logs.Enabled) ||
+		boolValue(cfg.OTel.Exporter.OTLP.Insecure) {
+		t.Fatalf("expected explicit disabled OpenTelemetry toggles to stay disabled, got %+v", cfg.OTel)
+	}
 }
 
 func TestConfigValidateRejectsInvalidValues(t *testing.T) {
@@ -228,6 +314,92 @@ func TestConfigDecodesWithMapstructure(t *testing.T) {
 	}
 }
 
+func TestConfigDecodePreservesExplicitDisabledToggles(t *testing.T) {
+	var cfg Config
+
+	err := sharedconfig.DecodeValues(context.Background(), map[string]any{
+		"cores": []any{
+			map[string]any{
+				"name":         "console",
+				"enabled":      false,
+				"type":         "console",
+				"level":        "info",
+				"encoding":     "console",
+				"output_paths": []any{"stdout"},
+				"datasets":     []any{"*"},
+			},
+			map[string]any{
+				"name":         "service-file",
+				"enabled":      false,
+				"type":         "file",
+				"level":        "info",
+				"encoding":     "json",
+				"output_paths": []any{DefaultFilePathTemplate},
+				"datasets":     []any{"*"},
+				"rotation": map[string]any{
+					"enabled":    false,
+					"compress":   false,
+					"local_time": false,
+				},
+			},
+		},
+		"buffering": map[string]any{
+			"enabled": false,
+		},
+		"redaction": map[string]any{
+			"enabled": false,
+		},
+		"otel": map[string]any{
+			"enabled": false,
+			"propagation": map[string]any{
+				"trace_context": false,
+				"baggage":       false,
+			},
+			"traces": map[string]any{
+				"enabled": false,
+			},
+			"metrics": map[string]any{
+				"enabled": false,
+			},
+			"logs": map[string]any{
+				"enabled": false,
+			},
+			"exporter": map[string]any{
+				"otlp": map[string]any{
+					"insecure": false,
+				},
+			},
+		},
+	}, &cfg, sharedconfig.Options{})
+	if err != nil {
+		t.Fatalf("decode logging config: %v", err)
+	}
+	if err := cfg.Default(); err != nil {
+		t.Fatalf("default logging config: %v", err)
+	}
+
+	if boolValue(cfg.Cores[0].Enabled) || boolValue(cfg.Cores[1].Enabled) {
+		t.Fatalf("expected decoded disabled cores to stay disabled, got %+v", cfg.Cores)
+	}
+	if boolValue(cfg.Cores[1].Rotation.Enabled) ||
+		boolValue(cfg.Cores[1].Rotation.Compress) ||
+		boolValue(cfg.Cores[1].Rotation.LocalTime) {
+		t.Fatalf("expected decoded disabled rotation settings to stay disabled, got %+v", cfg.Cores[1].Rotation)
+	}
+	if boolValue(cfg.Buffering.Enabled) || boolValue(cfg.Redaction.Enabled) {
+		t.Fatalf("expected decoded disabled buffering/redaction to stay disabled, got buffering=%+v redaction=%+v", cfg.Buffering, cfg.Redaction)
+	}
+	if boolValue(cfg.OTel.Enabled) ||
+		boolValue(cfg.OTel.Propagation.TraceContext) ||
+		boolValue(cfg.OTel.Propagation.Baggage) ||
+		boolValue(cfg.OTel.Traces.Enabled) ||
+		boolValue(cfg.OTel.Metrics.Enabled) ||
+		boolValue(cfg.OTel.Logs.Enabled) ||
+		boolValue(cfg.OTel.Exporter.OTLP.Insecure) {
+		t.Fatalf("expected decoded disabled OpenTelemetry toggles to stay disabled, got %+v", cfg.OTel)
+	}
+}
+
 func TestConfigJSONAndYAMLTags(t *testing.T) {
 	cfg := Config{}
 	if err := cfg.Default(); err != nil {
@@ -287,7 +459,7 @@ func assertCore(t *testing.T, core CoreConfig, name string, coreType CoreType, e
 	if core.Name != name {
 		t.Fatalf("expected core name %q, got %q", name, core.Name)
 	}
-	if !core.Enabled {
+	if !boolValue(core.Enabled) {
 		t.Fatalf("expected core %q to be enabled", name)
 	}
 	if core.Type != coreType {

--- a/packages/shared/logging/doc.go
+++ b/packages/shared/logging/doc.go
@@ -1,0 +1,32 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : doc.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-26
+ * @Modified: 2026-04-26
+ */
+
+// Package logging defines the shared Dox logging model and configuration
+// contract.
+//
+// This package is the first-stage observability vocabulary for Dox backend
+// runtimes. It defines resource identity, correlation, observability event,
+// EDA event, node, tag, field, and logging configuration types. It does not
+// initialize zap, lumberjack, OpenTelemetry SDK providers, runtime loggers, or
+// concrete sinks. Those are follow-up runtime integration milestones.
+package logging

--- a/packages/shared/logging/doc.go
+++ b/packages/shared/logging/doc.go
@@ -26,7 +26,7 @@
 //
 // This package is the first-stage observability vocabulary for Dox backend
 // runtimes. It defines resource identity, correlation, observability event,
-// EDA event, node, tag, field, and logging configuration types. It does not
-// initialize zap, lumberjack, OpenTelemetry SDK providers, runtime loggers, or
-// concrete sinks. Those are follow-up runtime integration milestones.
+// node, tag, field, and logging configuration types. It does not initialize
+// zap, lumberjack, OpenTelemetry SDK providers, runtime loggers, or concrete
+// sinks. Those are follow-up runtime integration milestones.
 package logging

--- a/packages/shared/logging/fields.go
+++ b/packages/shared/logging/fields.go
@@ -89,37 +89,6 @@ const (
 )
 
 const (
-	// FieldEDAEventID identifies a domain or message event.
-	FieldEDAEventID = "eda.event_id"
-	// FieldEDAEventType identifies a domain or message event type.
-	FieldEDAEventType = "eda.event_type"
-	// FieldEDAEventVersion identifies a domain event schema version.
-	FieldEDAEventVersion = "eda.event_version"
-	// FieldEDAEventSource identifies a domain event source.
-	FieldEDAEventSource = "eda.event_source"
-	// FieldEDASubject identifies the event subject.
-	FieldEDASubject = "eda.subject"
-	// FieldEDACorrelationID identifies the EDA correlation id.
-	FieldEDACorrelationID = "eda.correlation_id"
-	// FieldEDACausationID identifies the EDA causation id.
-	FieldEDACausationID = "eda.causation_id"
-	// FieldEDAMessageID identifies the broker message id.
-	FieldEDAMessageID = "eda.message_id"
-	// FieldEDATopic identifies the broker topic.
-	FieldEDATopic = "eda.topic"
-	// FieldEDAPartition identifies the broker partition.
-	FieldEDAPartition = "eda.partition"
-	// FieldEDAOffset identifies the broker offset.
-	FieldEDAOffset = "eda.offset"
-	// FieldEDAConsumerGroup identifies the consumer group.
-	FieldEDAConsumerGroup = "eda.consumer_group"
-	// FieldEDAConsumerID identifies the consumer instance.
-	FieldEDAConsumerID = "eda.consumer_id"
-	// FieldEDADeliveryAttempt identifies the delivery attempt.
-	FieldEDADeliveryAttempt = "eda.delivery_attempt"
-)
-
-const (
 	// FieldComponent identifies the service-internal component.
 	FieldComponent = "component"
 	// FieldOperation identifies the current operation.

--- a/packages/shared/logging/fields.go
+++ b/packages/shared/logging/fields.go
@@ -1,0 +1,131 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : fields.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-26
+ * @Modified: 2026-04-26
+ */
+
+package logging
+
+const (
+	// FieldServiceNamespace is the OpenTelemetry service namespace field.
+	FieldServiceNamespace = "service.namespace"
+	// FieldServiceName is the OpenTelemetry service name field.
+	FieldServiceName = "service.name"
+	// FieldServiceInstanceID is the OpenTelemetry service instance field.
+	FieldServiceInstanceID = "service.instance.id"
+	// FieldServiceVersion is the OpenTelemetry service version field.
+	FieldServiceVersion = "service.version"
+	// FieldDeploymentEnvironmentName identifies the deployment environment.
+	FieldDeploymentEnvironmentName = "deployment.environment.name"
+	// FieldCloudRegion identifies the cloud region.
+	FieldCloudRegion = "cloud.region"
+	// FieldCloudAvailabilityZone identifies the cloud availability zone.
+	FieldCloudAvailabilityZone = "cloud.availability_zone"
+	// FieldK8sClusterName identifies the Kubernetes cluster.
+	FieldK8sClusterName = "k8s.cluster.name"
+	// FieldK8sNamespaceName identifies the Kubernetes namespace.
+	FieldK8sNamespaceName = "k8s.namespace.name"
+	// FieldDoxOrganization identifies the Dox owning organization.
+	FieldDoxOrganization = "dox.organization"
+	// FieldDoxApplication identifies the Dox application family.
+	FieldDoxApplication = "dox.application"
+	// FieldDoxRuntime identifies the Dox runtime system.
+	FieldDoxRuntime = "dox.runtime"
+)
+
+const (
+	// FieldTraceID identifies an OpenTelemetry trace.
+	FieldTraceID = "trace_id"
+	// FieldSpanID identifies an OpenTelemetry span.
+	FieldSpanID = "span_id"
+	// FieldTraceFlags carries OpenTelemetry trace flags.
+	FieldTraceFlags = "trace_flags"
+	// FieldRequestID identifies an HTTP or API request.
+	FieldRequestID = "request_id"
+	// FieldCorrelationID identifies a Dox business execution chain.
+	FieldCorrelationID = "correlation_id"
+	// FieldJobID identifies a Dox job.
+	FieldJobID = "job_id"
+	// FieldTaskID identifies a Dox task.
+	FieldTaskID = "task_id"
+	// FieldWorkflowID identifies a Dox workflow.
+	FieldWorkflowID = "workflow_id"
+	// FieldPluginID identifies a Dox plugin.
+	FieldPluginID = "plugin_id"
+	// FieldPluginRunID identifies one plugin execution.
+	FieldPluginRunID = "plugin_run_id"
+)
+
+const (
+	// FieldEventName identifies the observability event name.
+	FieldEventName = "event.name"
+	// FieldEventDataset identifies the observability event dataset.
+	FieldEventDataset = "event.dataset"
+	// FieldEventCategory identifies the observability event category.
+	FieldEventCategory = "event.category"
+	// FieldEventType identifies the observability event type.
+	FieldEventType = "event.type"
+	// FieldEventAction identifies the observability event action.
+	FieldEventAction = "event.action"
+	// FieldEventOutcome identifies the observability event outcome.
+	FieldEventOutcome = "event.outcome"
+)
+
+const (
+	// FieldEDAEventID identifies a domain or message event.
+	FieldEDAEventID = "eda.event_id"
+	// FieldEDAEventType identifies a domain or message event type.
+	FieldEDAEventType = "eda.event_type"
+	// FieldEDAEventVersion identifies a domain event schema version.
+	FieldEDAEventVersion = "eda.event_version"
+	// FieldEDAEventSource identifies a domain event source.
+	FieldEDAEventSource = "eda.event_source"
+	// FieldEDASubject identifies the event subject.
+	FieldEDASubject = "eda.subject"
+	// FieldEDACorrelationID identifies the EDA correlation id.
+	FieldEDACorrelationID = "eda.correlation_id"
+	// FieldEDACausationID identifies the EDA causation id.
+	FieldEDACausationID = "eda.causation_id"
+	// FieldEDAMessageID identifies the broker message id.
+	FieldEDAMessageID = "eda.message_id"
+	// FieldEDATopic identifies the broker topic.
+	FieldEDATopic = "eda.topic"
+	// FieldEDAPartition identifies the broker partition.
+	FieldEDAPartition = "eda.partition"
+	// FieldEDAOffset identifies the broker offset.
+	FieldEDAOffset = "eda.offset"
+	// FieldEDAConsumerGroup identifies the consumer group.
+	FieldEDAConsumerGroup = "eda.consumer_group"
+	// FieldEDAConsumerID identifies the consumer instance.
+	FieldEDAConsumerID = "eda.consumer_id"
+	// FieldEDADeliveryAttempt identifies the delivery attempt.
+	FieldEDADeliveryAttempt = "eda.delivery_attempt"
+)
+
+const (
+	// FieldComponent identifies the service-internal component.
+	FieldComponent = "component"
+	// FieldOperation identifies the current operation.
+	FieldOperation = "operation"
+	// FieldTags stores low-cardinality business node labels.
+	FieldTags = "tags"
+	// FieldFields stores event facts and higher-cardinality details.
+	FieldFields = "fields"
+)

--- a/packages/shared/logging/model.go
+++ b/packages/shared/logging/model.go
@@ -63,24 +63,6 @@ type Event struct {
 	Outcome  string `json:"event.outcome,omitempty" yaml:"event.outcome,omitempty" mapstructure:"event.outcome"`
 }
 
-// EDAEvent describes domain or message event metadata involved in a log event.
-type EDAEvent struct {
-	EventID         string `json:"eda.event_id,omitempty" yaml:"eda.event_id,omitempty" mapstructure:"eda.event_id"`
-	EventType       string `json:"eda.event_type,omitempty" yaml:"eda.event_type,omitempty" mapstructure:"eda.event_type"`
-	EventVersion    string `json:"eda.event_version,omitempty" yaml:"eda.event_version,omitempty" mapstructure:"eda.event_version"`
-	EventSource     string `json:"eda.event_source,omitempty" yaml:"eda.event_source,omitempty" mapstructure:"eda.event_source"`
-	Subject         string `json:"eda.subject,omitempty" yaml:"eda.subject,omitempty" mapstructure:"eda.subject"`
-	CorrelationID   string `json:"eda.correlation_id,omitempty" yaml:"eda.correlation_id,omitempty" mapstructure:"eda.correlation_id"`
-	CausationID     string `json:"eda.causation_id,omitempty" yaml:"eda.causation_id,omitempty" mapstructure:"eda.causation_id"`
-	MessageID       string `json:"eda.message_id,omitempty" yaml:"eda.message_id,omitempty" mapstructure:"eda.message_id"`
-	Topic           string `json:"eda.topic,omitempty" yaml:"eda.topic,omitempty" mapstructure:"eda.topic"`
-	Partition       string `json:"eda.partition,omitempty" yaml:"eda.partition,omitempty" mapstructure:"eda.partition"`
-	Offset          string `json:"eda.offset,omitempty" yaml:"eda.offset,omitempty" mapstructure:"eda.offset"`
-	ConsumerGroup   string `json:"eda.consumer_group,omitempty" yaml:"eda.consumer_group,omitempty" mapstructure:"eda.consumer_group"`
-	ConsumerID      string `json:"eda.consumer_id,omitempty" yaml:"eda.consumer_id,omitempty" mapstructure:"eda.consumer_id"`
-	DeliveryAttempt int    `json:"eda.delivery_attempt,omitempty" yaml:"eda.delivery_attempt,omitempty" mapstructure:"eda.delivery_attempt"`
-}
-
 // Node describes where inside a service an event happened.
 type Node struct {
 	Component string `json:"component,omitempty" yaml:"component,omitempty" mapstructure:"component"`

--- a/packages/shared/logging/model.go
+++ b/packages/shared/logging/model.go
@@ -1,0 +1,94 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : model.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-26
+ * @Modified: 2026-04-26
+ */
+
+package logging
+
+// Resource describes the service instance that produced telemetry.
+type Resource struct {
+	ServiceNamespace      string `json:"service.namespace,omitempty" yaml:"service.namespace,omitempty" mapstructure:"service.namespace"`
+	ServiceName           string `json:"service.name,omitempty" yaml:"service.name,omitempty" mapstructure:"service.name"`
+	ServiceInstanceID     string `json:"service.instance.id,omitempty" yaml:"service.instance.id,omitempty" mapstructure:"service.instance.id"`
+	ServiceVersion        string `json:"service.version,omitempty" yaml:"service.version,omitempty" mapstructure:"service.version"`
+	DeploymentEnvironment string `json:"deployment.environment.name,omitempty" yaml:"deployment.environment.name,omitempty" mapstructure:"deployment.environment.name"`
+	CloudRegion           string `json:"cloud.region,omitempty" yaml:"cloud.region,omitempty" mapstructure:"cloud.region"`
+	CloudAvailabilityZone string `json:"cloud.availability_zone,omitempty" yaml:"cloud.availability_zone,omitempty" mapstructure:"cloud.availability_zone"`
+	K8sClusterName        string `json:"k8s.cluster.name,omitempty" yaml:"k8s.cluster.name,omitempty" mapstructure:"k8s.cluster.name"`
+	K8sNamespaceName      string `json:"k8s.namespace.name,omitempty" yaml:"k8s.namespace.name,omitempty" mapstructure:"k8s.namespace.name"`
+	DoxOrganization       string `json:"dox.organization,omitempty" yaml:"dox.organization,omitempty" mapstructure:"dox.organization"`
+	DoxApplication        string `json:"dox.application,omitempty" yaml:"dox.application,omitempty" mapstructure:"dox.application"`
+	DoxRuntime            string `json:"dox.runtime,omitempty" yaml:"dox.runtime,omitempty" mapstructure:"dox.runtime"`
+}
+
+// Correlation connects one request, task, plugin run, or event-driven chain.
+type Correlation struct {
+	TraceID       string `json:"trace_id,omitempty" yaml:"trace_id,omitempty" mapstructure:"trace_id"`
+	SpanID        string `json:"span_id,omitempty" yaml:"span_id,omitempty" mapstructure:"span_id"`
+	TraceFlags    string `json:"trace_flags,omitempty" yaml:"trace_flags,omitempty" mapstructure:"trace_flags"`
+	RequestID     string `json:"request_id,omitempty" yaml:"request_id,omitempty" mapstructure:"request_id"`
+	CorrelationID string `json:"correlation_id,omitempty" yaml:"correlation_id,omitempty" mapstructure:"correlation_id"`
+	JobID         string `json:"job_id,omitempty" yaml:"job_id,omitempty" mapstructure:"job_id"`
+	TaskID        string `json:"task_id,omitempty" yaml:"task_id,omitempty" mapstructure:"task_id"`
+	WorkflowID    string `json:"workflow_id,omitempty" yaml:"workflow_id,omitempty" mapstructure:"workflow_id"`
+	PluginID      string `json:"plugin_id,omitempty" yaml:"plugin_id,omitempty" mapstructure:"plugin_id"`
+	PluginRunID   string `json:"plugin_run_id,omitempty" yaml:"plugin_run_id,omitempty" mapstructure:"plugin_run_id"`
+}
+
+// Event describes the observability event represented by a log record.
+type Event struct {
+	Name     string `json:"event.name,omitempty" yaml:"event.name,omitempty" mapstructure:"event.name"`
+	Dataset  string `json:"event.dataset,omitempty" yaml:"event.dataset,omitempty" mapstructure:"event.dataset"`
+	Category string `json:"event.category,omitempty" yaml:"event.category,omitempty" mapstructure:"event.category"`
+	Type     string `json:"event.type,omitempty" yaml:"event.type,omitempty" mapstructure:"event.type"`
+	Action   string `json:"event.action,omitempty" yaml:"event.action,omitempty" mapstructure:"event.action"`
+	Outcome  string `json:"event.outcome,omitempty" yaml:"event.outcome,omitempty" mapstructure:"event.outcome"`
+}
+
+// EDAEvent describes domain or message event metadata involved in a log event.
+type EDAEvent struct {
+	EventID         string `json:"eda.event_id,omitempty" yaml:"eda.event_id,omitempty" mapstructure:"eda.event_id"`
+	EventType       string `json:"eda.event_type,omitempty" yaml:"eda.event_type,omitempty" mapstructure:"eda.event_type"`
+	EventVersion    string `json:"eda.event_version,omitempty" yaml:"eda.event_version,omitempty" mapstructure:"eda.event_version"`
+	EventSource     string `json:"eda.event_source,omitempty" yaml:"eda.event_source,omitempty" mapstructure:"eda.event_source"`
+	Subject         string `json:"eda.subject,omitempty" yaml:"eda.subject,omitempty" mapstructure:"eda.subject"`
+	CorrelationID   string `json:"eda.correlation_id,omitempty" yaml:"eda.correlation_id,omitempty" mapstructure:"eda.correlation_id"`
+	CausationID     string `json:"eda.causation_id,omitempty" yaml:"eda.causation_id,omitempty" mapstructure:"eda.causation_id"`
+	MessageID       string `json:"eda.message_id,omitempty" yaml:"eda.message_id,omitempty" mapstructure:"eda.message_id"`
+	Topic           string `json:"eda.topic,omitempty" yaml:"eda.topic,omitempty" mapstructure:"eda.topic"`
+	Partition       string `json:"eda.partition,omitempty" yaml:"eda.partition,omitempty" mapstructure:"eda.partition"`
+	Offset          string `json:"eda.offset,omitempty" yaml:"eda.offset,omitempty" mapstructure:"eda.offset"`
+	ConsumerGroup   string `json:"eda.consumer_group,omitempty" yaml:"eda.consumer_group,omitempty" mapstructure:"eda.consumer_group"`
+	ConsumerID      string `json:"eda.consumer_id,omitempty" yaml:"eda.consumer_id,omitempty" mapstructure:"eda.consumer_id"`
+	DeliveryAttempt int    `json:"eda.delivery_attempt,omitempty" yaml:"eda.delivery_attempt,omitempty" mapstructure:"eda.delivery_attempt"`
+}
+
+// Node describes where inside a service an event happened.
+type Node struct {
+	Component string `json:"component,omitempty" yaml:"component,omitempty" mapstructure:"component"`
+	Operation string `json:"operation,omitempty" yaml:"operation,omitempty" mapstructure:"operation"`
+}
+
+// Tags are low-cardinality business node labels.
+type Tags map[string]string
+
+// Fields are event facts and higher-cardinality details.
+type Fields map[string]any

--- a/packages/shared/logging/validate.go
+++ b/packages/shared/logging/validate.go
@@ -1,0 +1,343 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : validate.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-26
+ * @Modified: 2026-04-26
+ */
+
+package logging
+
+import (
+	"strconv"
+	"strings"
+)
+
+var levelEncoderNames = map[string]struct{}{
+	"lowercase":       {},
+	"lowercase_color": {},
+	"capital":         {},
+	"capital_color":   {},
+}
+
+var timeEncoderNames = map[string]struct{}{
+	"rfc3339nano": {},
+	"rfc3339":     {},
+	"iso8601":     {},
+	"epoch":       {},
+	"millis":      {},
+	"nanos":       {},
+}
+
+var durationEncoderNames = map[string]struct{}{
+	"seconds": {},
+	"millis":  {},
+	"nanos":   {},
+	"string":  {},
+}
+
+var callerEncoderNames = map[string]struct{}{
+	"short": {},
+	"full":  {},
+}
+
+var nameEncoderNames = map[string]struct{}{
+	"full": {},
+}
+
+// FieldError describes one logging configuration validation failure.
+type FieldError struct {
+	Field  string
+	Reason string
+}
+
+// ValidationError describes one or more logging validation failures.
+type ValidationError struct {
+	Fields []FieldError
+}
+
+// Error returns a compact validation failure message.
+func (e *ValidationError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if len(e.Fields) == 0 {
+		return "logging validation failed"
+	}
+
+	parts := make([]string, 0, len(e.Fields))
+	for _, field := range e.Fields {
+		if field.Reason == "" {
+			parts = append(parts, field.Field)
+			continue
+		}
+		parts = append(parts, field.Field+": "+field.Reason)
+	}
+	return "logging validation failed: " + strings.Join(parts, ", ")
+}
+
+// Validate verifies the shared logging configuration contract.
+func (c Config) Validate() error {
+	v := validator{}
+	v.level("level", c.Level)
+	c.Zap.validate(&v)
+	v.cores(c.Cores)
+	c.Buffering.validate(&v)
+	c.Shutdown.validate(&v)
+	c.Redaction.validate(&v)
+	c.OTel.validate(&v)
+	return v.err()
+}
+
+func (c ZapConfig) validate(v *validator) {
+	v.level("zap.level", c.Level)
+	v.encoding("zap.encoding", c.Encoding)
+	c.EncoderConfig.validate(v, "zap.encoder_config")
+	if len(c.OutputPaths) == 0 {
+		v.add("zap.output_paths", "at least one output path is required")
+	}
+	for index, path := range c.OutputPaths {
+		if strings.TrimSpace(path) == "" {
+			v.add(indexField("zap.output_paths", index), "output path must not be empty")
+		}
+	}
+	if len(c.ErrorOutputPaths) == 0 {
+		v.add("zap.error_output_paths", "at least one error output path is required")
+	}
+	for index, path := range c.ErrorOutputPaths {
+		if strings.TrimSpace(path) == "" {
+			v.add(indexField("zap.error_output_paths", index), "error output path must not be empty")
+		}
+	}
+	if c.Sampling.Enabled {
+		if c.Sampling.Initial <= 0 {
+			v.add("zap.sampling.initial", "initial must be positive when sampling is enabled")
+		}
+		if c.Sampling.Thereafter <= 0 {
+			v.add("zap.sampling.thereafter", "thereafter must be positive when sampling is enabled")
+		}
+	}
+}
+
+func (c EncoderConfig) validate(v *validator, field string) {
+	v.symbol(field+".level_encoder", c.LevelEncoder, levelEncoderNames)
+	v.symbol(field+".time_encoder", c.TimeEncoder, timeEncoderNames)
+	v.symbol(field+".duration_encoder", c.DurationEncoder, durationEncoderNames)
+	v.symbol(field+".caller_encoder", c.CallerEncoder, callerEncoderNames)
+	v.symbol(field+".name_encoder", c.NameEncoder, nameEncoderNames)
+}
+
+func (c BufferingConfig) validate(v *validator) {
+	if !c.Enabled {
+		return
+	}
+	if c.SizeBytes <= 0 {
+		v.add("buffering.size_bytes", "size must be positive when buffering is enabled")
+	}
+	if c.FlushInterval <= 0 {
+		v.add("buffering.flush_interval", "flush interval must be positive when buffering is enabled")
+	}
+}
+
+func (c ShutdownConfig) validate(v *validator) {
+	if c.Timeout <= 0 {
+		v.add("shutdown.timeout", "timeout must be positive")
+	}
+}
+
+func (c RedactionConfig) validate(v *validator) {
+	if !c.Enabled {
+		return
+	}
+	if strings.TrimSpace(c.Replacement) == "" {
+		v.add("redaction.replacement", "replacement must not be empty when redaction is enabled")
+	}
+	if len(c.Keys) == 0 {
+		v.add("redaction.keys", "at least one redaction key is required when redaction is enabled")
+	}
+	for index, key := range c.Keys {
+		if strings.TrimSpace(key) == "" {
+			v.add(indexField("redaction.keys", index), "redaction key must not be empty")
+		}
+	}
+}
+
+func (c OpenTelemetryConfig) validate(v *validator) {
+	if !c.Enabled {
+		return
+	}
+	c.Traces.validate(v)
+	c.Exporter.validate(v)
+	c.Batch.validate(v)
+}
+
+func (c OpenTelemetryTraces) validate(v *validator) {
+	if !c.Enabled {
+		return
+	}
+	if !c.Sampler.Type.IsValid() {
+		v.add("otel.traces.sampler.type", "trace sampler type is not supported")
+	}
+	if c.Sampler.Ratio < 0 || c.Sampler.Ratio > 1 {
+		v.add("otel.traces.sampler.ratio", "trace sampler ratio must be between 0 and 1")
+	}
+}
+
+func (c OpenTelemetryExporter) validate(v *validator) {
+	c.OTLP.validate(v)
+}
+
+func (c OTLPExporterConfig) validate(v *validator) {
+	if !c.Protocol.IsValid() {
+		v.add("otel.exporter.otlp.protocol", "OTLP protocol is not supported")
+	}
+	if c.Enabled && strings.TrimSpace(c.Endpoint) == "" {
+		v.add("otel.exporter.otlp.endpoint", "endpoint is required when OTLP exporter is enabled")
+	}
+	if c.Enabled && c.Timeout <= 0 {
+		v.add("otel.exporter.otlp.timeout", "timeout must be positive when OTLP exporter is enabled")
+	}
+	for key := range c.Headers {
+		if strings.TrimSpace(key) == "" {
+			v.add("otel.exporter.otlp.headers", "header keys must not be empty")
+		}
+	}
+}
+
+func (c OpenTelemetryBatch) validate(v *validator) {
+	if c.MaxQueueSize <= 0 {
+		v.add("otel.batch.max_queue_size", "max queue size must be positive")
+	}
+	if c.ScheduleDelay <= 0 {
+		v.add("otel.batch.schedule_delay", "schedule delay must be positive")
+	}
+	if c.ExportTimeout <= 0 {
+		v.add("otel.batch.export_timeout", "export timeout must be positive")
+	}
+	if c.MaxExportBatchSize <= 0 {
+		v.add("otel.batch.max_export_batch_size", "max export batch size must be positive")
+	}
+	if c.MaxExportBatchSize > c.MaxQueueSize {
+		v.add("otel.batch.max_export_batch_size", "max export batch size must not exceed max queue size")
+	}
+}
+
+type validator struct {
+	fields []FieldError
+}
+
+func (v *validator) cores(cores []CoreConfig) {
+	if len(cores) == 0 {
+		v.add("cores", "at least one core is required")
+		return
+	}
+	seen := map[string]struct{}{}
+	for index, core := range cores {
+		field := indexField("cores", index)
+		name := strings.TrimSpace(core.Name)
+		if name == "" {
+			v.add(field+".name", "core name is required")
+		} else if _, exists := seen[name]; exists {
+			v.add(field+".name", "core name must be unique")
+		} else {
+			seen[name] = struct{}{}
+		}
+
+		if !core.Type.IsValid() {
+			v.add(field+".type", "core type is not supported")
+		}
+		v.level(field+".level", core.Level)
+		v.encoding(field+".encoding", core.Encoding)
+		if core.Enabled && len(core.OutputPaths) == 0 {
+			v.add(field+".output_paths", "enabled core requires at least one output path")
+		}
+		for pathIndex, path := range core.OutputPaths {
+			if strings.TrimSpace(path) == "" {
+				v.add(indexField(field+".output_paths", pathIndex), "output path must not be empty")
+			}
+		}
+		if len(core.Datasets) == 0 {
+			v.add(field+".datasets", "at least one dataset routing entry is required")
+		}
+		for datasetIndex, dataset := range core.Datasets {
+			if strings.TrimSpace(dataset) == "" {
+				v.add(indexField(field+".datasets", datasetIndex), "dataset routing entry must not be empty")
+			}
+		}
+		if core.Type == CoreTypeFile {
+			core.Rotation.validate(v, field+".rotation")
+		}
+	}
+}
+
+func (c RotationConfig) validate(v *validator, field string) {
+	if !c.Driver.IsValid() {
+		v.add(field+".driver", "rotation driver is not supported")
+	}
+	if !c.Enabled {
+		return
+	}
+	if c.Driver == RotationDriverLumberjack {
+		if c.MaxSizeMB <= 0 {
+			v.add(field+".max_size_mb", "max size must be positive")
+		}
+		if c.MaxBackups < 0 {
+			v.add(field+".max_backups", "max backups must not be negative")
+		}
+		if c.MaxAgeDays < 0 {
+			v.add(field+".max_age_days", "max age must not be negative")
+		}
+	}
+}
+
+func (v *validator) level(field string, level Level) {
+	if !level.IsValid() {
+		v.add(field, "level is not supported")
+	}
+}
+
+func (v *validator) encoding(field string, encoding Encoding) {
+	if !encoding.IsValid() {
+		v.add(field, "encoding is not supported")
+	}
+}
+
+func (v *validator) symbol(field string, value string, allowed map[string]struct{}) {
+	if strings.TrimSpace(value) == "" {
+		v.add(field, "encoder name is required")
+		return
+	}
+	if _, ok := allowed[value]; !ok {
+		v.add(field, "encoder name is not supported")
+	}
+}
+
+func (v *validator) add(field string, reason string) {
+	v.fields = append(v.fields, FieldError{Field: field, Reason: reason})
+}
+
+func (v *validator) err() error {
+	if len(v.fields) == 0 {
+		return nil
+	}
+	return &ValidationError{Fields: v.fields}
+}
+
+func indexField(field string, index int) string {
+	return field + "[" + strconv.Itoa(index) + "]"
+}

--- a/packages/shared/logging/validate.go
+++ b/packages/shared/logging/validate.go
@@ -143,7 +143,7 @@ func (c EncoderConfig) validate(v *validator, field string) {
 }
 
 func (c BufferingConfig) validate(v *validator) {
-	if !c.Enabled {
+	if !boolValue(c.Enabled) {
 		return
 	}
 	if c.SizeBytes <= 0 {
@@ -161,7 +161,7 @@ func (c ShutdownConfig) validate(v *validator) {
 }
 
 func (c RedactionConfig) validate(v *validator) {
-	if !c.Enabled {
+	if !boolValue(c.Enabled) {
 		return
 	}
 	if strings.TrimSpace(c.Replacement) == "" {
@@ -178,7 +178,7 @@ func (c RedactionConfig) validate(v *validator) {
 }
 
 func (c OpenTelemetryConfig) validate(v *validator) {
-	if !c.Enabled {
+	if !boolValue(c.Enabled) {
 		return
 	}
 	c.Traces.validate(v)
@@ -187,7 +187,7 @@ func (c OpenTelemetryConfig) validate(v *validator) {
 }
 
 func (c OpenTelemetryTraces) validate(v *validator) {
-	if !c.Enabled {
+	if !boolValue(c.Enabled) {
 		return
 	}
 	if !c.Sampler.Type.IsValid() {
@@ -263,7 +263,7 @@ func (v *validator) cores(cores []CoreConfig) {
 		}
 		v.level(field+".level", core.Level)
 		v.encoding(field+".encoding", core.Encoding)
-		if core.Enabled && len(core.OutputPaths) == 0 {
+		if boolValue(core.Enabled) && len(core.OutputPaths) == 0 {
 			v.add(field+".output_paths", "enabled core requires at least one output path")
 		}
 		for pathIndex, path := range core.OutputPaths {
@@ -289,7 +289,7 @@ func (c RotationConfig) validate(v *validator, field string) {
 	if !c.Driver.IsValid() {
 		v.add(field+".driver", "rotation driver is not supported")
 	}
-	if !c.Enabled {
+	if !boolValue(c.Enabled) {
 		return
 	}
 	if c.Driver == RotationDriverLumberjack {


### PR DESCRIPTION
## Description

Adds the first shared logging contract package for Dox. The package defines observability logging vocabulary, configuration defaults, and validation without wiring any concrete logger backend or runtime integration.

## Related Links

- Closes #26
- Refs #24
- Refs #22
- Refs #20

## Scope

- [ ] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [x] Security

## Implementation Notes

- Adds `packages/shared/logging` as a declarative contract package.
- Defines resource, correlation, observability event, node, tags, and fields models.
- Defines stable field-name constants for resource identity, trace/correlation, `event.*`, node, tags, and fields.
- Adds backend-neutral configuration shapes for zap-facing settings, output cores, rotation, buffering, shutdown, redaction, and OpenTelemetry settings.
- Keeps sampling disabled by default.
- Uses pointer bools for default-on toggles so explicit `false` from decoded configuration is preserved.
- Keeps EDA domain/message event modeling out of the logging core. Future EDA integration should live in EDA-specific packages or adapters.
- Does not import zap, lumberjack, or OpenTelemetry SDK packages.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands run:

```sh
env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go test ./packages/shared/logging
env GOCACHE=/home/frost/workspace/.cache/go-build GOPATH=/home/frost/workspace/.gopath /home/frost/workspace/.tools/go1.25.6/bin/go test -count=1 ./packages/shared/... ./server/...
git diff --check
git verify-commit HEAD
```

## Risks

This PR only defines the first-stage contract. Runtime logger APIs, zap core construction, JSONL output, lumberjack rotation, OpenTelemetry SDK setup, and server bootstrap integration remain follow-up work.
