### PR TITLE
gh-28 [feat]: Add zap core base for shared logging

### DIFF
--- a/packages/shared/go.mod
+++ b/packages/shared/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/knadh/koanf/providers/confmap v1.0.0
 	github.com/knadh/koanf/v2 v2.3.4
 	github.com/pelletier/go-toml/v2 v2.3.0
+	go.uber.org/zap v1.27.1
 	go.yaml.in/yaml/v3 v3.0.4
 )
 
@@ -19,6 +20,7 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/packages/shared/go.sum
+++ b/packages/shared/go.sum
@@ -30,6 +30,12 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=
+go.uber.org/zap v1.27.1/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=

--- a/packages/shared/logging/README.md
+++ b/packages/shared/logging/README.md
@@ -25,7 +25,7 @@
 
 `packages/shared/logging` defines the shared Dox logging vocabulary and configuration contract.
 
-This package does not initialize zap, lumberjack, OpenTelemetry SDK providers, runtime loggers, or concrete sinks. Those belong to follow-up implementation work.
+This package maps the shared Dox logging configuration to zap and zapcore primitives for runtime integrations. It does not make zap the business logging API, and it does not initialize lumberjack, OpenTelemetry SDK providers, or the Dox logger facade.
 
 ## Boundary
 
@@ -41,10 +41,24 @@ The package owns stable names and configuration shapes for:
 
 The package must not:
 
-- expose `*zap.Logger`, `zap.Field`, or `zap.Config` as a business API;
-- import zap, lumberjack, or OpenTelemetry SDK packages in this first stage;
-- write logs to console, files, stdout, stderr, OTLP, or async queues;
+- expose `*zap.Logger` or `zap.Field` as a business API;
+- import lumberjack or OpenTelemetry SDK packages in the zap core base;
+- implement file rotation, OTLP, or async queues in the zap core base;
 - wire logging into server, scheduler, collector, compute, IAM, or HTTP middleware.
+
+## Zap Core Base
+
+The zap core base provides implementation helpers for runtime bootstrap code:
+
+- Dox `Level` to `zapcore.Level` and `zap.AtomicLevel` mapping;
+- symbolic encoder mapping for level, time, duration, caller, and logger name encoders;
+- `zap.Config` mapping with sampling disabled unless explicitly enabled;
+- enabled console and JSON core construction through zap output paths;
+- zap options for development mode, caller, stacktrace, error output, and initial fields.
+
+`DisableErrorVerbose` is applied by the core base so `zap.Error` fields keep the basic error string without adding zap's extra `errorVerbose` field.
+
+File core declarations currently use zap's basic output path support. Rotation fields stay in the configuration contract for the follow-up lumberjack v2 sink issue.
 
 ## Resource
 
@@ -231,7 +245,6 @@ cores:
 
 Separate issues should implement:
 
-- zap core base;
 - JSONL file sink and lumberjack v2 rotation;
 - Dox logger API and context correlation;
 - OpenTelemetry SDK base;

--- a/packages/shared/logging/config.go
+++ b/packages/shared/logging/config.go
@@ -170,7 +170,7 @@ type ResourceConfig struct {
 	ServiceVersion string `json:"service_version" yaml:"service_version" mapstructure:"service_version"`
 }
 
-// ZapConfig mirrors the zap.Config shape without importing zap.
+// ZapConfig mirrors the zap.Config shape with Dox-owned configuration fields.
 type ZapConfig struct {
 	Level               Level          `json:"level" yaml:"level" mapstructure:"level"`
 	Development         bool           `json:"development" yaml:"development" mapstructure:"development"`
@@ -204,7 +204,7 @@ type EncoderConfig struct {
 	ConsoleSeparator string `json:"console_separator" yaml:"console_separator" mapstructure:"console_separator"`
 }
 
-// SamplingConfig mirrors zap sampling configuration without importing zap.
+// SamplingConfig mirrors zap sampling configuration with Dox-owned toggles.
 type SamplingConfig struct {
 	Enabled     bool `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
 	Initial     int  `json:"initial" yaml:"initial" mapstructure:"initial"`

--- a/packages/shared/logging/doc.go
+++ b/packages/shared/logging/doc.go
@@ -26,7 +26,8 @@
 //
 // This package is the first-stage observability vocabulary for Dox backend
 // runtimes. It defines resource identity, correlation, observability event,
-// node, tag, field, and logging configuration types. It does not initialize
-// zap, lumberjack, OpenTelemetry SDK providers, runtime loggers, or concrete
-// sinks. Those are follow-up runtime integration milestones.
+// node, tag, field, and logging configuration types. It also maps the Dox
+// logging configuration to zap and zapcore primitives for runtime integration.
+// It does not initialize lumberjack, OpenTelemetry SDK providers, or the Dox
+// business logger API. Those are follow-up runtime integration milestones.
 package logging

--- a/packages/shared/logging/zap.go
+++ b/packages/shared/logging/zap.go
@@ -1,0 +1,436 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : zap.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-26
+ * @Modified: 2026-04-26
+ */
+
+package logging
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var zapLevelEncoders = map[string]zapcore.LevelEncoder{
+	"lowercase":       zapcore.LowercaseLevelEncoder,
+	"lowercase_color": zapcore.LowercaseColorLevelEncoder,
+	"capital":         zapcore.CapitalLevelEncoder,
+	"capital_color":   zapcore.CapitalColorLevelEncoder,
+}
+
+var zapTimeEncoders = map[string]zapcore.TimeEncoder{
+	"rfc3339nano": zapcore.RFC3339NanoTimeEncoder,
+	"rfc3339":     zapcore.RFC3339TimeEncoder,
+	"iso8601":     zapcore.ISO8601TimeEncoder,
+	"epoch":       zapcore.EpochTimeEncoder,
+	"millis":      zapcore.EpochMillisTimeEncoder,
+	"nanos":       zapcore.EpochNanosTimeEncoder,
+}
+
+var zapDurationEncoders = map[string]zapcore.DurationEncoder{
+	"seconds": zapcore.SecondsDurationEncoder,
+	"millis":  zapcore.MillisDurationEncoder,
+	"nanos":   zapcore.NanosDurationEncoder,
+	"string":  zapcore.StringDurationEncoder,
+}
+
+var zapCallerEncoders = map[string]zapcore.CallerEncoder{
+	"short": zapcore.ShortCallerEncoder,
+	"full":  zapcore.FullCallerEncoder,
+}
+
+var zapNameEncoders = map[string]zapcore.NameEncoder{
+	"full": zapcore.FullNameEncoder,
+}
+
+// ZapCoreBase carries zap primitives for runtime integrations.
+//
+// Business code should depend on Dox logging types and the future Dox logger
+// API instead of using these zap primitives directly.
+type ZapCoreBase struct {
+	Config       zap.Config
+	Level        zap.AtomicLevel
+	Core         zapcore.Core
+	EnabledCores int
+
+	options []zap.Option
+	close   func()
+}
+
+// Options returns zap options mapped from the Dox logging configuration.
+func (b *ZapCoreBase) Options() []zap.Option {
+	if b == nil || len(b.options) == 0 {
+		return nil
+	}
+	options := make([]zap.Option, len(b.options))
+	copy(options, b.options)
+	return options
+}
+
+// Close releases sinks opened by NewZapCoreBase.
+func (b *ZapCoreBase) Close() {
+	if b == nil || b.close == nil {
+		return
+	}
+	closeFn := b.close
+	b.close = nil
+	closeFn()
+}
+
+// NewZapLevel maps a Dox logging level to a zapcore level.
+func NewZapLevel(level Level) (zapcore.Level, error) {
+	switch level {
+	case LevelDebug:
+		return zapcore.DebugLevel, nil
+	case LevelInfo:
+		return zapcore.InfoLevel, nil
+	case LevelWarn:
+		return zapcore.WarnLevel, nil
+	case LevelError:
+		return zapcore.ErrorLevel, nil
+	case LevelDPanic:
+		return zapcore.DPanicLevel, nil
+	case LevelPanic:
+		return zapcore.PanicLevel, nil
+	case LevelFatal:
+		return zapcore.FatalLevel, nil
+	default:
+		return zapcore.InvalidLevel, validationError("level", "level is not supported")
+	}
+}
+
+// NewZapAtomicLevel creates a zap AtomicLevel from a Dox logging level.
+func NewZapAtomicLevel(level Level) (zap.AtomicLevel, error) {
+	zapLevel, err := NewZapLevel(level)
+	if err != nil {
+		return zap.AtomicLevel{}, err
+	}
+	return zap.NewAtomicLevelAt(zapLevel), nil
+}
+
+// NewZapEncoderConfig maps the Dox symbolic encoder config to zapcore.
+func NewZapEncoderConfig(config EncoderConfig) (zapcore.EncoderConfig, error) {
+	config.Default()
+	v := validator{}
+	config.validate(&v, "encoder_config")
+	if err := v.err(); err != nil {
+		return zapcore.EncoderConfig{}, err
+	}
+
+	return zapcore.EncoderConfig{
+		MessageKey:       config.MessageKey,
+		LevelKey:         config.LevelKey,
+		TimeKey:          config.TimeKey,
+		NameKey:          config.NameKey,
+		CallerKey:        config.CallerKey,
+		FunctionKey:      config.FunctionKey,
+		StacktraceKey:    config.StacktraceKey,
+		SkipLineEnding:   config.SkipLineEnding,
+		LineEnding:       config.LineEnding,
+		EncodeLevel:      zapLevelEncoders[config.LevelEncoder],
+		EncodeTime:       zapTimeEncoders[config.TimeEncoder],
+		EncodeDuration:   zapDurationEncoders[config.DurationEncoder],
+		EncodeCaller:     zapCallerEncoders[config.CallerEncoder],
+		EncodeName:       zapNameEncoders[config.NameEncoder],
+		ConsoleSeparator: config.ConsoleSeparator,
+	}, nil
+}
+
+// NewZapConfig maps the Dox logging configuration to zap.Config.
+func NewZapConfig(config Config) (zap.Config, error) {
+	normalized, err := normalizeZapConfig(config)
+	if err != nil {
+		return zap.Config{}, err
+	}
+	return newZapConfigFromNormalized(normalized)
+}
+
+// NewZapCoreBase builds enabled zap cores and options from the Dox config.
+func NewZapCoreBase(config Config) (*ZapCoreBase, error) {
+	normalized, err := normalizeZapConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	zapConfig, err := newZapConfigFromNormalized(normalized)
+	if err != nil {
+		return nil, err
+	}
+
+	errSink, closeErrSink, err := zap.Open(zapConfig.ErrorOutputPaths...)
+	if err != nil {
+		return nil, fmt.Errorf("logging: open zap error output paths: %w", err)
+	}
+
+	core, enabledCores, closeCore, err := newZapCoreFromNormalized(normalized, zapConfig.Level)
+	if err != nil {
+		closeErrSink()
+		return nil, err
+	}
+
+	return &ZapCoreBase{
+		Config:       zapConfig,
+		Level:        zapConfig.Level,
+		Core:         core,
+		EnabledCores: enabledCores,
+		options:      newZapOptions(normalized.Zap, errSink),
+		close: func() {
+			closeCore()
+			closeErrSink()
+		},
+	}, nil
+}
+
+func normalizeZapConfig(config Config) (Config, error) {
+	if err := config.Default(); err != nil {
+		return Config{}, err
+	}
+	if err := config.Validate(); err != nil {
+		return Config{}, err
+	}
+	return config, nil
+}
+
+func newZapConfigFromNormalized(config Config) (zap.Config, error) {
+	level, err := NewZapAtomicLevel(config.Zap.Level)
+	if err != nil {
+		return zap.Config{}, err
+	}
+	encoderConfig, err := NewZapEncoderConfig(config.Zap.EncoderConfig)
+	if err != nil {
+		return zap.Config{}, err
+	}
+
+	return zap.Config{
+		Level:             level,
+		Development:       config.Zap.Development,
+		DisableCaller:     config.Zap.DisableCaller,
+		DisableStacktrace: config.Zap.DisableStacktrace,
+		Sampling:          newZapSamplingConfig(config.Zap.Sampling),
+		Encoding:          string(config.Zap.Encoding),
+		EncoderConfig:     encoderConfig,
+		OutputPaths:       copyStrings(config.Zap.OutputPaths),
+		ErrorOutputPaths:  copyStrings(config.Zap.ErrorOutputPaths),
+		InitialFields:     copyInitialFields(config.Zap.InitialFields),
+	}, nil
+}
+
+func newZapCoreFromNormalized(config Config, rootLevel zap.AtomicLevel) (zapcore.Core, int, func(), error) {
+	encoderConfig, err := NewZapEncoderConfig(config.Zap.EncoderConfig)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	cores := make([]zapcore.Core, 0, len(config.Cores))
+	closeFns := make([]func(), 0, len(config.Cores))
+	for _, coreConfig := range config.Cores {
+		if !boolValue(coreConfig.Enabled) {
+			continue
+		}
+
+		encoder, err := newZapEncoder(coreConfig.Encoding, encoderConfig)
+		if err != nil {
+			closeZapSinks(closeFns)
+			return nil, 0, nil, fmt.Errorf("logging: build zap core %q: %w", coreConfig.Name, err)
+		}
+		writer, closeWriter, err := zap.Open(coreConfig.OutputPaths...)
+		if err != nil {
+			closeZapSinks(closeFns)
+			return nil, 0, nil, fmt.Errorf("logging: open zap core %q output paths: %w", coreConfig.Name, err)
+		}
+		closeFns = append(closeFns, closeWriter)
+
+		coreLevel, err := NewZapLevel(coreConfig.Level)
+		if err != nil {
+			closeZapSinks(closeFns)
+			return nil, 0, nil, fmt.Errorf("logging: build zap core %q: %w", coreConfig.Name, err)
+		}
+		cores = append(cores, zapcore.NewCore(encoder, writer, zapCoreLevelEnabler(rootLevel, coreLevel)))
+	}
+
+	core := zapcore.NewTee(cores...)
+	if config.Zap.DisableErrorVerbose {
+		core = noErrorVerboseCore{Core: core}
+	}
+	if config.Zap.Sampling.Enabled {
+		core = zapcore.NewSamplerWithOptions(
+			core,
+			time.Second,
+			config.Zap.Sampling.Initial,
+			config.Zap.Sampling.Thereafter,
+		)
+	}
+
+	return core, len(cores), func() {
+		closeZapSinks(closeFns)
+	}, nil
+}
+
+func newZapEncoder(encoding Encoding, config zapcore.EncoderConfig) (zapcore.Encoder, error) {
+	switch encoding {
+	case EncodingConsole:
+		return zapcore.NewConsoleEncoder(config), nil
+	case EncodingJSON:
+		return zapcore.NewJSONEncoder(config), nil
+	default:
+		return nil, validationError("encoding", "encoding is not supported")
+	}
+}
+
+func newZapSamplingConfig(config SamplingConfig) *zap.SamplingConfig {
+	if !config.Enabled {
+		return nil
+	}
+	return &zap.SamplingConfig{
+		Initial:    config.Initial,
+		Thereafter: config.Thereafter,
+	}
+}
+
+func newZapOptions(config ZapConfig, errSink zapcore.WriteSyncer) []zap.Option {
+	options := []zap.Option{zap.ErrorOutput(errSink)}
+	if config.Development {
+		options = append(options, zap.Development())
+	}
+	if !config.DisableCaller {
+		options = append(options, zap.AddCaller())
+	}
+	if !config.DisableStacktrace {
+		stackLevel := zapcore.ErrorLevel
+		if config.Development {
+			stackLevel = zapcore.WarnLevel
+		}
+		options = append(options, zap.AddStacktrace(stackLevel))
+	}
+	if fields := newZapInitialFields(config.InitialFields); len(fields) > 0 {
+		options = append(options, zap.Fields(fields...))
+	}
+	return options
+}
+
+func newZapInitialFields(fields map[string]any) []zap.Field {
+	if len(fields) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	zapFields := make([]zap.Field, 0, len(fields))
+	for _, key := range keys {
+		zapFields = append(zapFields, zap.Any(key, fields[key]))
+	}
+	return zapFields
+}
+
+func zapCoreLevelEnabler(rootLevel zap.AtomicLevel, coreLevel zapcore.Level) zapcore.LevelEnabler {
+	return zap.LevelEnablerFunc(func(level zapcore.Level) bool {
+		return rootLevel.Enabled(level) && coreLevel.Enabled(level)
+	})
+}
+
+func copyStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	copied := make([]string, len(values))
+	copy(copied, values)
+	return copied
+}
+
+func copyInitialFields(values map[string]any) map[string]any {
+	if values == nil {
+		return nil
+	}
+	copied := make(map[string]any, len(values))
+	for key, value := range values {
+		copied[key] = value
+	}
+	return copied
+}
+
+func closeZapSinks(closeFns []func()) {
+	for _, closeFn := range closeFns {
+		closeFn()
+	}
+}
+
+func validationError(field string, reason string) error {
+	return &ValidationError{
+		Fields: []FieldError{
+			{
+				Field:  field,
+				Reason: reason,
+			},
+		},
+	}
+}
+
+type noErrorVerboseCore struct {
+	zapcore.Core
+}
+
+func (c noErrorVerboseCore) With(fields []zapcore.Field) zapcore.Core {
+	return noErrorVerboseCore{Core: c.Core.With(disableErrorVerboseFields(fields))}
+}
+
+func (c noErrorVerboseCore) Check(entry zapcore.Entry, checked *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(entry.Level) {
+		return checked.AddCore(entry, c)
+	}
+	return checked
+}
+
+func (c noErrorVerboseCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	return c.Core.Write(entry, disableErrorVerboseFields(fields))
+}
+
+func disableErrorVerboseFields(fields []zapcore.Field) []zapcore.Field {
+	var copied []zapcore.Field
+	for index, field := range fields {
+		if field.Type != zapcore.ErrorType {
+			continue
+		}
+		err, ok := field.Interface.(error)
+		if !ok || err == nil {
+			continue
+		}
+		if copied == nil {
+			copied = make([]zapcore.Field, len(fields))
+			copy(copied, fields)
+		}
+		copied[index] = zapcore.Field{
+			Key:    field.Key,
+			Type:   zapcore.StringType,
+			String: err.Error(),
+		}
+	}
+	if copied == nil {
+		return fields
+	}
+	return copied
+}

--- a/packages/shared/logging/zap_test.go
+++ b/packages/shared/logging/zap_test.go
@@ -1,0 +1,463 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : zap_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-26
+ * @Modified: 2026-04-26
+ */
+
+package logging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestNewZapLevelMapsDoxLevels(t *testing.T) {
+	tests := []struct {
+		name     string
+		level    Level
+		expected zapcore.Level
+	}{
+		{name: "debug", level: LevelDebug, expected: zapcore.DebugLevel},
+		{name: "info", level: LevelInfo, expected: zapcore.InfoLevel},
+		{name: "warn", level: LevelWarn, expected: zapcore.WarnLevel},
+		{name: "error", level: LevelError, expected: zapcore.ErrorLevel},
+		{name: "dpanic", level: LevelDPanic, expected: zapcore.DPanicLevel},
+		{name: "panic", level: LevelPanic, expected: zapcore.PanicLevel},
+		{name: "fatal", level: LevelFatal, expected: zapcore.FatalLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			level, err := NewZapLevel(tt.level)
+			if err != nil {
+				t.Fatalf("map zap level: %v", err)
+			}
+			if level != tt.expected {
+				t.Fatalf("expected zap level %s, got %s", tt.expected, level)
+			}
+		})
+	}
+
+	if _, err := NewZapLevel(Level("trace")); !hasValidationField(err, "level") {
+		t.Fatalf("expected package validation error for invalid level, got %v", err)
+	}
+}
+
+func TestNewZapAtomicLevelMapsDoxLevel(t *testing.T) {
+	level, err := NewZapAtomicLevel(LevelWarn)
+	if err != nil {
+		t.Fatalf("map zap atomic level: %v", err)
+	}
+	if level.Level() != zapcore.WarnLevel {
+		t.Fatalf("expected warn atomic level, got %s", level.Level())
+	}
+	level.SetLevel(zapcore.ErrorLevel)
+	if level.Enabled(zapcore.WarnLevel) {
+		t.Fatal("expected updated atomic level to reject warn")
+	}
+}
+
+func TestNewZapEncoderConfigMapsSymbols(t *testing.T) {
+	config := EncoderConfig{
+		MessageKey:       "message",
+		LevelKey:         "severity_text",
+		TimeKey:          "timestamp",
+		NameKey:          "logger",
+		CallerKey:        "caller",
+		FunctionKey:      "function",
+		StacktraceKey:    "stacktrace",
+		LineEnding:       "\n",
+		LevelEncoder:     "lowercase",
+		TimeEncoder:      "iso8601",
+		DurationEncoder:  "seconds",
+		CallerEncoder:    "full",
+		NameEncoder:      "full",
+		ConsoleSeparator: " | ",
+	}
+
+	encoderConfig, err := NewZapEncoderConfig(config)
+	if err != nil {
+		t.Fatalf("map zap encoder config: %v", err)
+	}
+
+	encoder := zapcore.NewJSONEncoder(encoderConfig)
+	buffer, err := encoder.EncodeEntry(zapcore.Entry{
+		Level:      zapcore.WarnLevel,
+		Time:       time.Date(2026, 4, 26, 10, 11, 12, 0, time.UTC),
+		LoggerName: "iam",
+		Caller: zapcore.EntryCaller{
+			Defined: true,
+			File:    "/srv/dox/auth.go",
+			Line:    42,
+		},
+		Message: "login rejected",
+	}, nil)
+	if err != nil {
+		t.Fatalf("encode entry: %v", err)
+	}
+	defer buffer.Free()
+
+	text := buffer.String()
+	for _, expected := range []string{
+		`"severity_text":"warn"`,
+		`"message":"login rejected"`,
+		`"logger":"iam"`,
+		`"caller":"/srv/dox/auth.go:42"`,
+		`"timestamp":"2026-04-26T10:11:12.000Z"`,
+	} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("expected encoded entry to contain %s, got %s", expected, text)
+		}
+	}
+}
+
+func TestNewZapEncoderConfigSupportsAllConfiguredSymbols(t *testing.T) {
+	for _, name := range []string{"lowercase", "lowercase_color", "capital", "capital_color"} {
+		config := EncoderConfig{LevelEncoder: name}
+		if _, err := NewZapEncoderConfig(config); err != nil {
+			t.Fatalf("expected level encoder %q to be supported: %v", name, err)
+		}
+	}
+	for _, name := range []string{"rfc3339nano", "rfc3339", "iso8601", "epoch", "millis", "nanos"} {
+		config := EncoderConfig{TimeEncoder: name}
+		if _, err := NewZapEncoderConfig(config); err != nil {
+			t.Fatalf("expected time encoder %q to be supported: %v", name, err)
+		}
+	}
+	for _, name := range []string{"seconds", "millis", "nanos", "string"} {
+		config := EncoderConfig{DurationEncoder: name}
+		if _, err := NewZapEncoderConfig(config); err != nil {
+			t.Fatalf("expected duration encoder %q to be supported: %v", name, err)
+		}
+	}
+	for _, name := range []string{"short", "full"} {
+		config := EncoderConfig{CallerEncoder: name}
+		if _, err := NewZapEncoderConfig(config); err != nil {
+			t.Fatalf("expected caller encoder %q to be supported: %v", name, err)
+		}
+	}
+
+	if _, err := NewZapEncoderConfig(EncoderConfig{LevelEncoder: "shout"}); !hasValidationField(err, "encoder_config.level_encoder") {
+		t.Fatalf("expected package validation error for invalid encoder, got %v", err)
+	}
+}
+
+func TestNewZapConfigMapsDoxZapConfig(t *testing.T) {
+	config := Config{
+		Level:       LevelDebug,
+		Development: true,
+		Zap: ZapConfig{
+			Level:               LevelWarn,
+			Development:         true,
+			DisableCaller:       true,
+			DisableStacktrace:   true,
+			DisableErrorVerbose: true,
+			Encoding:            EncodingConsole,
+			EncoderConfig: EncoderConfig{
+				MessageKey:      "msg",
+				LevelEncoder:    "capital",
+				TimeEncoder:     "rfc3339",
+				DurationEncoder: "string",
+				CallerEncoder:   "short",
+				NameEncoder:     "full",
+			},
+			OutputPaths:      []string{"stdout"},
+			ErrorOutputPaths: []string{"stderr"},
+			InitialFields: map[string]any{
+				"service.name": "iam",
+			},
+			Sampling: SamplingConfig{
+				Enabled:    true,
+				Initial:    3,
+				Thereafter: 4,
+			},
+		},
+	}
+
+	zapConfig, err := NewZapConfig(config)
+	if err != nil {
+		t.Fatalf("map zap config: %v", err)
+	}
+
+	if zapConfig.Level.Level() != zapcore.WarnLevel {
+		t.Fatalf("expected warn level, got %s", zapConfig.Level.Level())
+	}
+	if !zapConfig.Development || !zapConfig.DisableCaller || !zapConfig.DisableStacktrace {
+		t.Fatalf("expected development/caller/stacktrace settings, got %+v", zapConfig)
+	}
+	if zapConfig.Encoding != "console" {
+		t.Fatalf("expected console encoding, got %q", zapConfig.Encoding)
+	}
+	if zapConfig.OutputPaths[0] != "stdout" || zapConfig.ErrorOutputPaths[0] != "stderr" {
+		t.Fatalf("expected output paths to map, got outputs=%#v errors=%#v", zapConfig.OutputPaths, zapConfig.ErrorOutputPaths)
+	}
+	if zapConfig.InitialFields["service.name"] != "iam" {
+		t.Fatalf("expected initial fields to map, got %#v", zapConfig.InitialFields)
+	}
+	if zapConfig.Sampling == nil || zapConfig.Sampling.Initial != 3 || zapConfig.Sampling.Thereafter != 4 {
+		t.Fatalf("expected sampling config to map, got %+v", zapConfig.Sampling)
+	}
+}
+
+func TestNewZapConfigKeepsSamplingDisabledByDefault(t *testing.T) {
+	zapConfig, err := NewZapConfig(Config{})
+	if err != nil {
+		t.Fatalf("map default zap config: %v", err)
+	}
+	if zapConfig.Sampling != nil {
+		t.Fatalf("expected nil zap sampling config by default, got %+v", zapConfig.Sampling)
+	}
+}
+
+func TestNewZapCoreBaseWritesEnabledConsoleAndJSONCores(t *testing.T) {
+	tempDir := t.TempDir()
+	consolePath := filepath.Join(tempDir, "console.log")
+	jsonPath := filepath.Join(tempDir, "service.jsonl")
+
+	base, err := NewZapCoreBase(Config{
+		Level: LevelDebug,
+		Zap: ZapConfig{
+			Level:             LevelDebug,
+			DisableCaller:     true,
+			DisableStacktrace: true,
+			ErrorOutputPaths:  []string{filepath.Join(tempDir, "errors.log")},
+			InitialFields: map[string]any{
+				"service.name": "iam",
+			},
+		},
+		Cores: []CoreConfig{
+			{
+				Name:        "console",
+				Enabled:     boolPtr(true),
+				Type:        CoreTypeConsole,
+				Level:       LevelDebug,
+				Encoding:    EncodingConsole,
+				OutputPaths: []string{consolePath},
+				Datasets:    []string{"*"},
+			},
+			{
+				Name:        "service-file",
+				Enabled:     boolPtr(true),
+				Type:        CoreTypeFile,
+				Level:       LevelInfo,
+				Encoding:    EncodingJSON,
+				OutputPaths: []string{jsonPath},
+				Datasets:    []string{"*"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build zap core base: %v", err)
+	}
+	t.Cleanup(base.Close)
+
+	if base.EnabledCores != 2 {
+		t.Fatalf("expected two enabled cores, got %d", base.EnabledCores)
+	}
+
+	logger := zap.New(base.Core, base.Options()...)
+	logger.Debug("debug-only")
+	logger.Info("login rejected", zap.String("credential_type", "password"))
+	_ = logger.Sync()
+	base.Close()
+
+	consoleText := readFile(t, consolePath)
+	if !strings.Contains(consoleText, "debug-only") || !strings.Contains(consoleText, "login rejected") {
+		t.Fatalf("expected console core to receive debug and info logs, got %s", consoleText)
+	}
+
+	jsonText := readFile(t, jsonPath)
+	if strings.Contains(jsonText, "debug-only") {
+		t.Fatalf("expected JSON core level to drop debug log, got %s", jsonText)
+	}
+	for _, expected := range []string{
+		`"message":"login rejected"`,
+		`"credential_type":"password"`,
+		`"service.name":"iam"`,
+	} {
+		if !strings.Contains(jsonText, expected) {
+			t.Fatalf("expected JSON output to contain %s, got %s", expected, jsonText)
+		}
+	}
+}
+
+func TestNewZapCoreBaseSkipsDisabledCores(t *testing.T) {
+	base, err := NewZapCoreBase(Config{
+		Zap: ZapConfig{
+			DisableCaller:     true,
+			DisableStacktrace: true,
+			ErrorOutputPaths:  []string{"stderr"},
+		},
+		Cores: []CoreConfig{
+			{
+				Name:     "disabled",
+				Enabled:  boolPtr(false),
+				Type:     CoreTypeConsole,
+				Level:    LevelInfo,
+				Encoding: EncodingConsole,
+				Datasets: []string{"*"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build zap core base: %v", err)
+	}
+	t.Cleanup(base.Close)
+
+	if base.EnabledCores != 0 {
+		t.Fatalf("expected no enabled cores, got %d", base.EnabledCores)
+	}
+	if base.Core.Enabled(zapcore.InfoLevel) {
+		t.Fatal("expected no-op core to reject info")
+	}
+}
+
+func TestNewZapCoreBaseSuppressesVerboseErrors(t *testing.T) {
+	tempDir := t.TempDir()
+	jsonPath := filepath.Join(tempDir, "service.jsonl")
+
+	base, err := NewZapCoreBase(Config{
+		Zap: ZapConfig{
+			DisableCaller:       true,
+			DisableStacktrace:   true,
+			DisableErrorVerbose: true,
+			ErrorOutputPaths:    []string{filepath.Join(tempDir, "errors.log")},
+		},
+		Cores: []CoreConfig{
+			{
+				Name:        "service-file",
+				Enabled:     boolPtr(true),
+				Type:        CoreTypeFile,
+				Level:       LevelInfo,
+				Encoding:    EncodingJSON,
+				OutputPaths: []string{jsonPath},
+				Datasets:    []string{"*"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build zap core base: %v", err)
+	}
+	t.Cleanup(base.Close)
+
+	logger := zap.New(base.Core, base.Options()...)
+	logger.Error("failed", zap.Error(verboseTestError{}))
+	_ = logger.Sync()
+	base.Close()
+
+	jsonText := readFile(t, jsonPath)
+	if strings.Contains(jsonText, "errorVerbose") {
+		t.Fatalf("expected verbose error field to be suppressed, got %s", jsonText)
+	}
+	if !strings.Contains(jsonText, `"error":"basic"`) {
+		t.Fatalf("expected basic error field, got %s", jsonText)
+	}
+}
+
+func TestNewZapCoreBaseSamplingDefaultAndExplicitEnable(t *testing.T) {
+	tests := []struct {
+		name          string
+		sampling      SamplingConfig
+		expectedCount int
+	}{
+		{name: "default disabled", sampling: SamplingConfig{}, expectedCount: 3},
+		{name: "explicit enabled", sampling: SamplingConfig{Enabled: true, Initial: 1, Thereafter: 100}, expectedCount: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			jsonPath := filepath.Join(tempDir, "service.jsonl")
+
+			base, err := NewZapCoreBase(Config{
+				Zap: ZapConfig{
+					DisableCaller:     true,
+					DisableStacktrace: true,
+					ErrorOutputPaths:  []string{filepath.Join(tempDir, "errors.log")},
+					Sampling:          tt.sampling,
+				},
+				Cores: []CoreConfig{
+					{
+						Name:        "service-file",
+						Enabled:     boolPtr(true),
+						Type:        CoreTypeFile,
+						Level:       LevelInfo,
+						Encoding:    EncodingJSON,
+						OutputPaths: []string{jsonPath},
+						Datasets:    []string{"*"},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("build zap core base: %v", err)
+			}
+			t.Cleanup(base.Close)
+
+			logger := zap.New(base.Core, base.Options()...)
+			for index := 0; index < 3; index++ {
+				logger.Info("sampled")
+			}
+			_ = logger.Sync()
+			base.Close()
+
+			jsonText := readFile(t, jsonPath)
+			if count := strings.Count(jsonText, `"message":"sampled"`); count != tt.expectedCount {
+				t.Fatalf("expected %d sampled log entries, got %d in %s", tt.expectedCount, count, jsonText)
+			}
+		})
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(content)
+}
+
+type verboseTestError struct{}
+
+func (verboseTestError) Error() string {
+	return "basic"
+}
+
+func (verboseTestError) Format(state fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if state.Flag('+') {
+			_, _ = fmt.Fprint(state, "verbose")
+			return
+		}
+		_, _ = fmt.Fprint(state, "basic")
+	case 's':
+		_, _ = fmt.Fprint(state, "basic")
+	case 'q':
+		_, _ = fmt.Fprint(state, `"basic"`)
+	}
+}


### PR DESCRIPTION
## Description

Adds the zap core base for the shared logging package introduced in #26. The implementation maps Dox-owned logging configuration into zap and zapcore primitives while keeping zap out of the business logger API.

## Related Links

- Closes #28
- Refs #26

## Scope

- [ ] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [ ] Security
- [x] Backend

## Implementation Notes

- Adds `go.uber.org/zap` to `packages/shared`.
- Maps Dox log levels to `zapcore.Level` and `zap.AtomicLevel`.
- Maps symbolic encoder config into `zapcore.EncoderConfig`.
- Maps Dox `Config` / `ZapConfig` into `zap.Config` without enabling sampling by default.
- Builds enabled console and JSON zap cores and combines them with `zapcore.NewTee`.
- Preserves issue boundaries: no lumberjack rotation, OpenTelemetry SDK initialization, runtime wiring, context correlation, Dox business logger API, or EDA-specific types.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands run:

```sh
go test -count=1 ./packages/shared/... ./server/...
git diff --check
git verify-commit HEAD
```

## Risks

This PR establishes the zap implementation base only. JSONL file rotation via lumberjack v2 and the Dox business logger API remain follow-up issues.
