### PR TITLE
gh-30 [feat]: Add JSONL lumberjack file sink

### DIFF
--- a/packages/shared/go.mod
+++ b/packages/shared/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.3.0
 	go.uber.org/zap v1.27.1
 	go.yaml.in/yaml/v3 v3.0.4
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
 require (

--- a/packages/shared/go.sum
+++ b/packages/shared/go.sum
@@ -46,5 +46,7 @@ golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
 golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/packages/shared/logging/README.md
+++ b/packages/shared/logging/README.md
@@ -25,7 +25,7 @@
 
 `packages/shared/logging` defines the shared Dox logging vocabulary and configuration contract.
 
-This package maps the shared Dox logging configuration to zap and zapcore primitives for runtime integrations. It does not make zap the business logging API, and it does not initialize lumberjack, OpenTelemetry SDK providers, or the Dox logger facade.
+This package maps the shared Dox logging configuration to zap, zapcore, and lumberjack primitives for runtime integrations. It does not make zap the business logging API, and it does not initialize OpenTelemetry SDK providers or the Dox logger facade.
 
 ## Boundary
 
@@ -42,8 +42,8 @@ The package owns stable names and configuration shapes for:
 The package must not:
 
 - expose `*zap.Logger` or `zap.Field` as a business API;
-- import lumberjack or OpenTelemetry SDK packages in the zap core base;
-- implement file rotation, OTLP, or async queues in the zap core base;
+- expose lumberjack as a business logging API;
+- implement OTLP or async queues in the zap core base;
 - wire logging into server, scheduler, collector, compute, IAM, or HTTP middleware.
 
 ## Zap Core Base
@@ -54,11 +54,14 @@ The zap core base provides implementation helpers for runtime bootstrap code:
 - symbolic encoder mapping for level, time, duration, caller, and logger name encoders;
 - `zap.Config` mapping with sampling disabled unless explicitly enabled;
 - enabled console and JSON core construction through zap output paths;
+- JSONL file core construction with optional lumberjack v2 rotation;
 - zap options for development mode, caller, stacktrace, error output, and initial fields.
 
 `DisableErrorVerbose` is applied by the core base so `zap.Error` fields keep the basic error string without adding zap's extra `errorVerbose` field.
 
-File core declarations currently use zap's basic output path support. Rotation fields stay in the configuration contract for the follow-up lumberjack v2 sink issue.
+File core declarations with `rotation.driver: lumberjack` use `gopkg.in/natefinch/lumberjack.v2`. The writer assumes only one process writes to the configured files on the same machine. Dox runtime deployment must avoid sharing the same rotating file path across multiple processes.
+
+File core declarations with `rotation.driver: none` use zap's basic file output path support without an internal rotator. `external` and `logrotate` remain configuration contract values for future runtime integration and are not supported by the zap file sink yet.
 
 ## Resource
 
@@ -245,7 +248,6 @@ cores:
 
 Separate issues should implement:
 
-- JSONL file sink and lumberjack v2 rotation;
 - Dox logger API and context correlation;
 - OpenTelemetry SDK base;
 - server setting and bootstrap integration;

--- a/packages/shared/logging/doc.go
+++ b/packages/shared/logging/doc.go
@@ -27,7 +27,7 @@
 // This package is the first-stage observability vocabulary for Dox backend
 // runtimes. It defines resource identity, correlation, observability event,
 // node, tag, field, and logging configuration types. It also maps the Dox
-// logging configuration to zap and zapcore primitives for runtime integration.
-// It does not initialize lumberjack, OpenTelemetry SDK providers, or the Dox
+// logging configuration to zap, zapcore, and lumberjack primitives for runtime
+// integration. It does not initialize OpenTelemetry SDK providers or the Dox
 // business logger API. Those are follow-up runtime integration milestones.
 package logging

--- a/packages/shared/logging/zap.go
+++ b/packages/shared/logging/zap.go
@@ -30,6 +30,7 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 var zapLevelEncoders = map[string]zapcore.LevelEncoder{
@@ -244,17 +245,18 @@ func newZapCoreFromNormalized(config Config, rootLevel zap.AtomicLevel) (zapcore
 
 	cores := make([]zapcore.Core, 0, len(config.Cores))
 	closeFns := make([]func(), 0, len(config.Cores))
-	for _, coreConfig := range config.Cores {
+	for index, coreConfig := range config.Cores {
 		if !boolValue(coreConfig.Enabled) {
 			continue
 		}
+		field := indexField("cores", index)
 
 		encoder, err := newZapEncoder(coreConfig.Encoding, encoderConfig)
 		if err != nil {
 			closeZapSinks(closeFns)
 			return nil, 0, nil, fmt.Errorf("logging: build zap core %q: %w", coreConfig.Name, err)
 		}
-		writer, closeWriter, err := zap.Open(coreConfig.OutputPaths...)
+		writer, closeWriter, err := newZapCoreWriter(coreConfig, field)
 		if err != nil {
 			closeZapSinks(closeFns)
 			return nil, 0, nil, fmt.Errorf("logging: open zap core %q output paths: %w", coreConfig.Name, err)
@@ -296,6 +298,54 @@ func newZapEncoder(encoding Encoding, config zapcore.EncoderConfig) (zapcore.Enc
 	default:
 		return nil, validationError("encoding", "encoding is not supported")
 	}
+}
+
+func newZapCoreWriter(config CoreConfig, field string) (zapcore.WriteSyncer, func(), error) {
+	if config.Type != CoreTypeFile {
+		return openZapPaths(config.OutputPaths)
+	}
+
+	switch config.Rotation.Driver {
+	case RotationDriverLumberjack:
+		if !boolValue(config.Rotation.Enabled) {
+			return openZapPaths(config.OutputPaths)
+		}
+		logger, err := newLumberjackLogger(config, field)
+		if err != nil {
+			return nil, nil, err
+		}
+		return zapcore.Lock(zapcore.AddSync(logger)), func() {
+			_ = logger.Close()
+		}, nil
+	case RotationDriverNone:
+		return openZapPaths(config.OutputPaths)
+	default:
+		return nil, nil, validationError(field+".rotation.driver", "rotation driver is not supported by the zap file sink")
+	}
+}
+
+func openZapPaths(paths []string) (zapcore.WriteSyncer, func(), error) {
+	writer, closeWriter, err := zap.Open(paths...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return writer, closeWriter, nil
+}
+
+func newLumberjackLogger(config CoreConfig, field string) (*lumberjack.Logger, error) {
+	if len(config.OutputPaths) != 1 {
+		return nil, validationError(field+".output_paths", "lumberjack file core requires exactly one output path")
+	}
+
+	rotation := config.Rotation
+	return &lumberjack.Logger{
+		Filename:   config.OutputPaths[0],
+		MaxSize:    rotation.MaxSizeMB,
+		MaxBackups: rotation.MaxBackups,
+		MaxAge:     rotation.MaxAgeDays,
+		Compress:   boolValue(rotation.Compress),
+		LocalTime:  boolValue(rotation.LocalTime),
+	}, nil
 }
 
 func newZapSamplingConfig(config SamplingConfig) *zap.SamplingConfig {

--- a/packages/shared/logging/zap_test.go
+++ b/packages/shared/logging/zap_test.go
@@ -24,6 +24,7 @@
 package logging
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -336,6 +337,220 @@ func TestNewZapCoreBaseSkipsDisabledCores(t *testing.T) {
 	}
 }
 
+func TestNewLumberjackLoggerMapsRotationConfig(t *testing.T) {
+	coreConfig := CoreConfig{
+		Name:        "service-file",
+		Enabled:     boolPtr(true),
+		Type:        CoreTypeFile,
+		Level:       LevelInfo,
+		Encoding:    EncodingJSON,
+		OutputPaths: []string{"/var/log/dox/service.jsonl"},
+		Datasets:    []string{"*"},
+		Rotation: RotationConfig{
+			Driver:     RotationDriverLumberjack,
+			Enabled:    boolPtr(true),
+			MaxSizeMB:  64,
+			MaxBackups: 7,
+			MaxAgeDays: 5,
+			Compress:   boolPtr(true),
+			LocalTime:  boolPtr(true),
+		},
+	}
+
+	logger, err := newLumberjackLogger(coreConfig, "cores[0]")
+	if err != nil {
+		t.Fatalf("map lumberjack logger: %v", err)
+	}
+
+	if logger.Filename != "/var/log/dox/service.jsonl" ||
+		logger.MaxSize != 64 ||
+		logger.MaxBackups != 7 ||
+		logger.MaxAge != 5 ||
+		!logger.Compress ||
+		!logger.LocalTime {
+		t.Fatalf("expected lumberjack config to map, got %+v", logger)
+	}
+}
+
+func TestNewZapCoreBaseWritesLumberjackJSONLFileCore(t *testing.T) {
+	tempDir := t.TempDir()
+	jsonPath := filepath.Join(tempDir, "service.jsonl")
+
+	base, err := NewZapCoreBase(Config{
+		Zap: ZapConfig{
+			DisableCaller:     true,
+			DisableStacktrace: true,
+			ErrorOutputPaths:  []string{filepath.Join(tempDir, "errors.log")},
+		},
+		Cores: []CoreConfig{
+			{
+				Name:        "service-file",
+				Enabled:     boolPtr(true),
+				Type:        CoreTypeFile,
+				Level:       LevelInfo,
+				Encoding:    EncodingJSON,
+				OutputPaths: []string{jsonPath},
+				Datasets:    []string{"*"},
+				Rotation: RotationConfig{
+					Driver:     RotationDriverLumberjack,
+					Enabled:    boolPtr(true),
+					MaxSizeMB:  1,
+					MaxBackups: 2,
+					MaxAgeDays: 3,
+					Compress:   boolPtr(false),
+					LocalTime:  boolPtr(false),
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build zap core base: %v", err)
+	}
+	t.Cleanup(base.Close)
+
+	logger := zap.New(base.Core, base.Options()...)
+	logger.Info("login accepted", zap.String("event.name", "iam.login.accepted"))
+	_ = logger.Sync()
+	base.Close()
+
+	entries := readJSONLines(t, jsonPath)
+	if len(entries) != 1 {
+		t.Fatalf("expected one JSONL entry, got %d: %#v", len(entries), entries)
+	}
+	if entries[0]["message"] != "login accepted" || entries[0]["event.name"] != "iam.login.accepted" {
+		t.Fatalf("expected JSONL fields to be written, got %#v", entries[0])
+	}
+	if base.close != nil {
+		t.Fatal("expected ZapCoreBase.Close to clear the close function")
+	}
+}
+
+func TestNewZapCoreBaseWritesNoRotationFileCore(t *testing.T) {
+	tempDir := t.TempDir()
+	jsonPath := filepath.Join(tempDir, "service.jsonl")
+
+	base, err := NewZapCoreBase(Config{
+		Zap: ZapConfig{
+			DisableCaller:     true,
+			DisableStacktrace: true,
+			ErrorOutputPaths:  []string{filepath.Join(tempDir, "errors.log")},
+		},
+		Cores: []CoreConfig{
+			{
+				Name:        "service-file",
+				Enabled:     boolPtr(true),
+				Type:        CoreTypeFile,
+				Level:       LevelInfo,
+				Encoding:    EncodingJSON,
+				OutputPaths: []string{jsonPath},
+				Datasets:    []string{"*"},
+				Rotation: RotationConfig{
+					Driver: RotationDriverNone,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build zap core base: %v", err)
+	}
+	t.Cleanup(base.Close)
+
+	logger := zap.New(base.Core, base.Options()...)
+	logger.Info("no rotation")
+	_ = logger.Sync()
+	base.Close()
+
+	entries := readJSONLines(t, jsonPath)
+	if len(entries) != 1 || entries[0]["message"] != "no rotation" {
+		t.Fatalf("expected no-rotation JSONL entry, got %#v", entries)
+	}
+}
+
+func TestNewZapCoreBaseRejectsUnsupportedFileRotationDriver(t *testing.T) {
+	tempDir := t.TempDir()
+
+	_, err := NewZapCoreBase(Config{
+		Zap: ZapConfig{
+			DisableCaller:     true,
+			DisableStacktrace: true,
+			ErrorOutputPaths:  []string{filepath.Join(tempDir, "errors.log")},
+		},
+		Cores: []CoreConfig{
+			{
+				Name:        "service-file",
+				Enabled:     boolPtr(true),
+				Type:        CoreTypeFile,
+				Level:       LevelInfo,
+				Encoding:    EncodingJSON,
+				OutputPaths: []string{filepath.Join(tempDir, "service.jsonl")},
+				Datasets:    []string{"*"},
+				Rotation: RotationConfig{
+					Driver: RotationDriverExternal,
+				},
+			},
+		},
+	})
+	if !hasValidationField(err, "cores[0].rotation.driver") {
+		t.Fatalf("expected unsupported rotation driver validation error, got %v", err)
+	}
+}
+
+func TestNewZapCoreBaseRejectsInvalidLumberjackOutputPaths(t *testing.T) {
+	tempDir := t.TempDir()
+
+	tests := []struct {
+		name        string
+		outputPaths []string
+		field       string
+	}{
+		{
+			name:        "empty",
+			outputPaths: []string{""},
+			field:       "cores[0].output_paths[0]",
+		},
+		{
+			name:        "multiple",
+			outputPaths: []string{filepath.Join(tempDir, "first.jsonl"), filepath.Join(tempDir, "second.jsonl")},
+			field:       "cores[0].output_paths",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewZapCoreBase(Config{
+				Zap: ZapConfig{
+					DisableCaller:     true,
+					DisableStacktrace: true,
+					ErrorOutputPaths:  []string{filepath.Join(tempDir, "errors.log")},
+				},
+				Cores: []CoreConfig{
+					{
+						Name:        "service-file",
+						Enabled:     boolPtr(true),
+						Type:        CoreTypeFile,
+						Level:       LevelInfo,
+						Encoding:    EncodingJSON,
+						OutputPaths: tt.outputPaths,
+						Datasets:    []string{"*"},
+						Rotation: RotationConfig{
+							Driver:     RotationDriverLumberjack,
+							Enabled:    boolPtr(true),
+							MaxSizeMB:  1,
+							MaxBackups: 1,
+							MaxAgeDays: 1,
+							Compress:   boolPtr(false),
+							LocalTime:  boolPtr(false),
+						},
+					},
+				},
+			})
+			if !hasValidationField(err, tt.field) {
+				t.Fatalf("expected validation field %s, got %v", tt.field, err)
+			}
+		})
+	}
+}
+
 func TestNewZapCoreBaseSuppressesVerboseErrors(t *testing.T) {
 	tempDir := t.TempDir()
 	jsonPath := filepath.Join(tempDir, "service.jsonl")
@@ -439,6 +654,25 @@ func readFile(t *testing.T, path string) string {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return string(content)
+}
+
+func readJSONLines(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	text := strings.TrimSpace(readFile(t, path))
+	if text == "" {
+		t.Fatalf("expected %s to contain JSONL entries", path)
+	}
+
+	lines := strings.Split(text, "\n")
+	entries := make([]map[string]any, 0, len(lines))
+	for index, line := range lines {
+		entry := map[string]any{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("parse JSONL line %d from %s: %v\n%s", index, path, err, line)
+		}
+		entries = append(entries, entry)
+	}
+	return entries
 }
 
 type verboseTestError struct{}


### PR DESCRIPTION
## Description

Adds JSONL file sink support with lumberjack v2 rotation behind the shared logging zap core base. File cores can now use Dox `RotationConfig` to select a lumberjack-backed writer, while no-rotation file cores and console cores keep using zap output paths.

## Related Links

- Closes #30
- Refs #26
- Refs #28
- Docs: https://pkg.go.dev/gopkg.in/natefinch/lumberjack.v2
- Docs: https://pkg.go.dev/go.uber.org/zap/zapcore

## Scope

- [ ] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [ ] Security
- [x] Backend

## Implementation Notes

- Adds `gopkg.in/natefinch/lumberjack.v2` to `packages/shared`.
- Routes file core writer construction by rotation driver.
- Maps lumberjack filename, max size, max backups, max age, compression, and local time from Dox config.
- Keeps `rotation.driver: none` on zap output paths without internal rotation.
- Returns package validation errors for unsupported file sink rotation drivers and invalid lumberjack output path shapes.
- Documents lumberjack's single-process writer assumption.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands run:

```sh
go test -count=1 ./packages/shared/logging
go test -count=1 ./packages/shared/... ./server/...
git diff --check
git verify-commit HEAD
```

## Risks

This PR adds the file sink implementation only. The Dox business logger API, context correlation, OpenTelemetry SDK setup, runtime wiring, and collection examples remain follow-up work.
