### PR TITLE
gh-32 [feat]: Add Dox logger API and context correlation

### DIFF
--- a/packages/shared/logging/README.md
+++ b/packages/shared/logging/README.md
@@ -25,7 +25,7 @@
 
 `packages/shared/logging` defines the shared Dox logging vocabulary and configuration contract.
 
-This package maps the shared Dox logging configuration to zap, zapcore, and lumberjack primitives for runtime integrations. It does not make zap the business logging API, and it does not initialize OpenTelemetry SDK providers or the Dox logger facade.
+This package maps the shared Dox logging configuration to zap, zapcore, and lumberjack primitives for runtime integrations. It also exposes the Dox-owned logger facade for business code. It does not initialize OpenTelemetry SDK providers or runtime wiring.
 
 ## Boundary
 
@@ -45,6 +45,19 @@ The package must not:
 - expose lumberjack as a business logging API;
 - implement OTLP or async queues in the zap core base;
 - wire logging into server, scheduler, collector, compute, IAM, or HTTP middleware.
+
+## Logger API
+
+Business code should depend on `logging.Logger` and `logging.Attr`, not zap.
+
+The facade supports:
+
+- `Debug`, `Info`, `Warn`, `Error`, `DPanic`, `Panic`, and `Fatal`;
+- `Named`, `With`, and `Sync`;
+- `ResourceAttr`, `CorrelationAttr`, `EventAttr`, `NodeAttr`, `TagsAttr`, `FieldsAttr`, `FieldAttr`, and `ErrorAttr`;
+- context correlation through `ContextWithCorrelation`, `ContextWithMergedCorrelation`, `CorrelationFromContext`, and `MergeCorrelation`.
+
+Runtime bootstrap code constructs a `ZapCoreBase` from configuration, then wraps it with `NewLogger`. HTTP middleware, scheduler jobs, collector runs, and compute tasks should add correlation to context in later integration issues.
 
 ## Zap Core Base
 
@@ -248,7 +261,6 @@ cores:
 
 Separate issues should implement:
 
-- Dox logger API and context correlation;
 - OpenTelemetry SDK base;
 - server setting and bootstrap integration;
 - HTTP correlation middleware;

--- a/packages/shared/logging/context.go
+++ b/packages/shared/logging/context.go
@@ -1,0 +1,86 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : context.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-27
+ * @Modified: 2026-04-27
+ */
+
+package logging
+
+import "context"
+
+type correlationContextKey struct{}
+
+// ContextWithCorrelation stores correlation values on ctx.
+func ContextWithCorrelation(ctx context.Context, correlation Correlation) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, correlationContextKey{}, correlation)
+}
+
+// ContextWithMergedCorrelation merges correlation values into ctx.
+func ContextWithMergedCorrelation(ctx context.Context, correlation Correlation) context.Context {
+	base, _ := CorrelationFromContext(ctx)
+	return ContextWithCorrelation(ctx, MergeCorrelation(base, correlation))
+}
+
+// CorrelationFromContext retrieves correlation values from ctx.
+func CorrelationFromContext(ctx context.Context) (Correlation, bool) {
+	if ctx == nil {
+		return Correlation{}, false
+	}
+	correlation, ok := ctx.Value(correlationContextKey{}).(Correlation)
+	return correlation, ok
+}
+
+// MergeCorrelation returns base with non-empty overlay values applied.
+func MergeCorrelation(base Correlation, overlay Correlation) Correlation {
+	if overlay.TraceID != "" {
+		base.TraceID = overlay.TraceID
+	}
+	if overlay.SpanID != "" {
+		base.SpanID = overlay.SpanID
+	}
+	if overlay.TraceFlags != "" {
+		base.TraceFlags = overlay.TraceFlags
+	}
+	if overlay.RequestID != "" {
+		base.RequestID = overlay.RequestID
+	}
+	if overlay.CorrelationID != "" {
+		base.CorrelationID = overlay.CorrelationID
+	}
+	if overlay.JobID != "" {
+		base.JobID = overlay.JobID
+	}
+	if overlay.TaskID != "" {
+		base.TaskID = overlay.TaskID
+	}
+	if overlay.WorkflowID != "" {
+		base.WorkflowID = overlay.WorkflowID
+	}
+	if overlay.PluginID != "" {
+		base.PluginID = overlay.PluginID
+	}
+	if overlay.PluginRunID != "" {
+		base.PluginRunID = overlay.PluginRunID
+	}
+	return base
+}

--- a/packages/shared/logging/doc.go
+++ b/packages/shared/logging/doc.go
@@ -28,6 +28,7 @@
 // runtimes. It defines resource identity, correlation, observability event,
 // node, tag, field, and logging configuration types. It also maps the Dox
 // logging configuration to zap, zapcore, and lumberjack primitives for runtime
-// integration. It does not initialize OpenTelemetry SDK providers or the Dox
-// business logger API. Those are follow-up runtime integration milestones.
+// integration and exposes the Dox-owned logger facade. It does not initialize
+// OpenTelemetry SDK providers or runtime wiring. Those are follow-up runtime
+// integration milestones.
 package logging

--- a/packages/shared/logging/logger.go
+++ b/packages/shared/logging/logger.go
@@ -1,0 +1,518 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : logger.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-27
+ * @Modified: 2026-04-27
+ */
+
+package logging
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"go.uber.org/zap"
+)
+
+// Logger is the Dox-owned business logging facade.
+type Logger interface {
+	Debug(ctx context.Context, message string, attrs ...Attr)
+	Info(ctx context.Context, message string, attrs ...Attr)
+	Warn(ctx context.Context, message string, attrs ...Attr)
+	Error(ctx context.Context, message string, attrs ...Attr)
+	DPanic(ctx context.Context, message string, attrs ...Attr)
+	Panic(ctx context.Context, message string, attrs ...Attr)
+	Fatal(ctx context.Context, message string, attrs ...Attr)
+	Named(name string) Logger
+	With(attrs ...Attr) Logger
+	Sync() error
+}
+
+// Attr attaches Dox logging model values to a logger or log call.
+type Attr struct {
+	apply func(*logValues)
+}
+
+// ResourceAttr attaches resource identity fields.
+func ResourceAttr(resource Resource) Attr {
+	return Attr{apply: func(values *logValues) {
+		values.resource = mergeResource(values.resource, resource)
+	}}
+}
+
+// CorrelationAttr attaches correlation fields.
+func CorrelationAttr(correlation Correlation) Attr {
+	return Attr{apply: func(values *logValues) {
+		values.correlation = MergeCorrelation(values.correlation, correlation)
+	}}
+}
+
+// EventAttr attaches observability event fields.
+func EventAttr(event Event) Attr {
+	return Attr{apply: func(values *logValues) {
+		values.event = mergeEvent(values.event, event)
+	}}
+}
+
+// NodeAttr attaches service-internal node fields.
+func NodeAttr(node Node) Attr {
+	return Attr{apply: func(values *logValues) {
+		values.node = mergeNode(values.node, node)
+	}}
+}
+
+// TagsAttr attaches low-cardinality business tags.
+func TagsAttr(tags Tags) Attr {
+	return Attr{apply: func(values *logValues) {
+		if len(tags) == 0 {
+			return
+		}
+		if values.tags == nil {
+			values.tags = Tags{}
+		}
+		for key, value := range tags {
+			if key == "" {
+				continue
+			}
+			values.tags[key] = value
+		}
+	}}
+}
+
+// FieldsAttr attaches event facts and higher-cardinality fields.
+func FieldsAttr(fields Fields) Attr {
+	return Attr{apply: func(values *logValues) {
+		if len(fields) == 0 {
+			return
+		}
+		if values.fields == nil {
+			values.fields = Fields{}
+		}
+		for key, value := range fields {
+			if key == "" {
+				continue
+			}
+			values.fields[key] = value
+		}
+	}}
+}
+
+// FieldAttr attaches one event fact under the Dox fields object.
+func FieldAttr(key string, value any) Attr {
+	return Attr{apply: func(values *logValues) {
+		if key == "" {
+			return
+		}
+		if values.fields == nil {
+			values.fields = Fields{}
+		}
+		values.fields[key] = value
+	}}
+}
+
+// ErrorAttr attaches an error to the log record.
+func ErrorAttr(err error) Attr {
+	return Attr{apply: func(values *logValues) {
+		values.err = err
+	}}
+}
+
+// NewLogger wraps an initialized zap core base with the Dox logger facade.
+func NewLogger(base *ZapCoreBase, attrs ...Attr) (Logger, error) {
+	if base == nil {
+		return nil, errors.New("logging: zap core base must not be nil")
+	}
+
+	options := base.Options()
+	options = append(options, zap.AddCallerSkip(1))
+
+	logger := zap.New(base.Core, options...)
+	values := logValues{}
+	values.apply(attrs...)
+	return doxLogger{
+		logger: logger,
+		values: values,
+	}, nil
+}
+
+type doxLogger struct {
+	logger *zap.Logger
+	values logValues
+}
+
+func (l doxLogger) Debug(ctx context.Context, message string, attrs ...Attr) {
+	l.write(ctx, LevelDebug, message, attrs...)
+}
+
+func (l doxLogger) Info(ctx context.Context, message string, attrs ...Attr) {
+	l.write(ctx, LevelInfo, message, attrs...)
+}
+
+func (l doxLogger) Warn(ctx context.Context, message string, attrs ...Attr) {
+	l.write(ctx, LevelWarn, message, attrs...)
+}
+
+func (l doxLogger) Error(ctx context.Context, message string, attrs ...Attr) {
+	l.write(ctx, LevelError, message, attrs...)
+}
+
+func (l doxLogger) DPanic(ctx context.Context, message string, attrs ...Attr) {
+	l.write(ctx, LevelDPanic, message, attrs...)
+}
+
+func (l doxLogger) Panic(ctx context.Context, message string, attrs ...Attr) {
+	l.write(ctx, LevelPanic, message, attrs...)
+}
+
+func (l doxLogger) Fatal(ctx context.Context, message string, attrs ...Attr) {
+	l.write(ctx, LevelFatal, message, attrs...)
+}
+
+func (l doxLogger) Named(name string) Logger {
+	if l.logger == nil || name == "" {
+		return l
+	}
+	l.logger = l.logger.Named(name)
+	return l
+}
+
+func (l doxLogger) With(attrs ...Attr) Logger {
+	l.values.apply(attrs...)
+	return l
+}
+
+func (l doxLogger) Sync() error {
+	if l.logger == nil {
+		return nil
+	}
+	return l.logger.Sync()
+}
+
+func (l doxLogger) write(ctx context.Context, level Level, message string, attrs ...Attr) {
+	if l.logger == nil {
+		return
+	}
+
+	values := l.values.clone()
+	if correlation, ok := CorrelationFromContext(ctx); ok {
+		values.correlation = MergeCorrelation(values.correlation, correlation)
+	}
+	values.apply(attrs...)
+	fields := values.zapFields()
+
+	switch level {
+	case LevelDebug:
+		l.logger.Debug(message, fields...)
+	case LevelInfo:
+		l.logger.Info(message, fields...)
+	case LevelWarn:
+		l.logger.Warn(message, fields...)
+	case LevelError:
+		l.logger.Error(message, fields...)
+	case LevelDPanic:
+		l.logger.DPanic(message, fields...)
+	case LevelPanic:
+		l.logger.Panic(message, fields...)
+	case LevelFatal:
+		l.logger.Fatal(message, fields...)
+	}
+}
+
+type logValues struct {
+	resource    Resource
+	correlation Correlation
+	event       Event
+	node        Node
+	tags        Tags
+	fields      Fields
+	err         error
+}
+
+func (v *logValues) apply(attrs ...Attr) {
+	for _, attr := range attrs {
+		if attr.apply != nil {
+			attr.apply(v)
+		}
+	}
+}
+
+func (v logValues) clone() logValues {
+	return logValues{
+		resource:    v.resource,
+		correlation: v.correlation,
+		event:       v.event,
+		node:        v.node,
+		tags:        copyTags(v.tags),
+		fields:      copyFields(v.fields),
+		err:         v.err,
+	}
+}
+
+func (v logValues) zapFields() []zap.Field {
+	fields := make([]zap.Field, 0, 32)
+	fields = appendResourceFields(fields, v.resource)
+	fields = appendCorrelationFields(fields, v.correlation)
+	fields = appendEventFields(fields, v.event)
+	fields = appendNodeFields(fields, v.node)
+	if len(v.tags) > 0 {
+		fields = append(fields, zap.Any(FieldTags, sortedTags(v.tags)))
+	}
+	if len(v.fields) > 0 {
+		fields = append(fields, zap.Any(FieldFields, sortedFields(v.fields)))
+	}
+	if v.err != nil {
+		fields = append(fields, zap.Error(v.err))
+	}
+	return fields
+}
+
+func appendResourceFields(fields []zap.Field, resource Resource) []zap.Field {
+	if resource.ServiceNamespace != "" {
+		fields = append(fields, zap.String(FieldServiceNamespace, resource.ServiceNamespace))
+	}
+	if resource.ServiceName != "" {
+		fields = append(fields, zap.String(FieldServiceName, resource.ServiceName))
+	}
+	if resource.ServiceInstanceID != "" {
+		fields = append(fields, zap.String(FieldServiceInstanceID, resource.ServiceInstanceID))
+	}
+	if resource.ServiceVersion != "" {
+		fields = append(fields, zap.String(FieldServiceVersion, resource.ServiceVersion))
+	}
+	if resource.DeploymentEnvironment != "" {
+		fields = append(fields, zap.String(FieldDeploymentEnvironmentName, resource.DeploymentEnvironment))
+	}
+	if resource.CloudRegion != "" {
+		fields = append(fields, zap.String(FieldCloudRegion, resource.CloudRegion))
+	}
+	if resource.CloudAvailabilityZone != "" {
+		fields = append(fields, zap.String(FieldCloudAvailabilityZone, resource.CloudAvailabilityZone))
+	}
+	if resource.K8sClusterName != "" {
+		fields = append(fields, zap.String(FieldK8sClusterName, resource.K8sClusterName))
+	}
+	if resource.K8sNamespaceName != "" {
+		fields = append(fields, zap.String(FieldK8sNamespaceName, resource.K8sNamespaceName))
+	}
+	if resource.DoxOrganization != "" {
+		fields = append(fields, zap.String(FieldDoxOrganization, resource.DoxOrganization))
+	}
+	if resource.DoxApplication != "" {
+		fields = append(fields, zap.String(FieldDoxApplication, resource.DoxApplication))
+	}
+	if resource.DoxRuntime != "" {
+		fields = append(fields, zap.String(FieldDoxRuntime, resource.DoxRuntime))
+	}
+	return fields
+}
+
+func appendCorrelationFields(fields []zap.Field, correlation Correlation) []zap.Field {
+	if correlation.TraceID != "" {
+		fields = append(fields, zap.String(FieldTraceID, correlation.TraceID))
+	}
+	if correlation.SpanID != "" {
+		fields = append(fields, zap.String(FieldSpanID, correlation.SpanID))
+	}
+	if correlation.TraceFlags != "" {
+		fields = append(fields, zap.String(FieldTraceFlags, correlation.TraceFlags))
+	}
+	if correlation.RequestID != "" {
+		fields = append(fields, zap.String(FieldRequestID, correlation.RequestID))
+	}
+	if correlation.CorrelationID != "" {
+		fields = append(fields, zap.String(FieldCorrelationID, correlation.CorrelationID))
+	}
+	if correlation.JobID != "" {
+		fields = append(fields, zap.String(FieldJobID, correlation.JobID))
+	}
+	if correlation.TaskID != "" {
+		fields = append(fields, zap.String(FieldTaskID, correlation.TaskID))
+	}
+	if correlation.WorkflowID != "" {
+		fields = append(fields, zap.String(FieldWorkflowID, correlation.WorkflowID))
+	}
+	if correlation.PluginID != "" {
+		fields = append(fields, zap.String(FieldPluginID, correlation.PluginID))
+	}
+	if correlation.PluginRunID != "" {
+		fields = append(fields, zap.String(FieldPluginRunID, correlation.PluginRunID))
+	}
+	return fields
+}
+
+func appendEventFields(fields []zap.Field, event Event) []zap.Field {
+	if event.Name != "" {
+		fields = append(fields, zap.String(FieldEventName, event.Name))
+	}
+	if event.Dataset != "" {
+		fields = append(fields, zap.String(FieldEventDataset, event.Dataset))
+	}
+	if event.Category != "" {
+		fields = append(fields, zap.String(FieldEventCategory, event.Category))
+	}
+	if event.Type != "" {
+		fields = append(fields, zap.String(FieldEventType, event.Type))
+	}
+	if event.Action != "" {
+		fields = append(fields, zap.String(FieldEventAction, event.Action))
+	}
+	if event.Outcome != "" {
+		fields = append(fields, zap.String(FieldEventOutcome, event.Outcome))
+	}
+	return fields
+}
+
+func appendNodeFields(fields []zap.Field, node Node) []zap.Field {
+	if node.Component != "" {
+		fields = append(fields, zap.String(FieldComponent, node.Component))
+	}
+	if node.Operation != "" {
+		fields = append(fields, zap.String(FieldOperation, node.Operation))
+	}
+	return fields
+}
+
+func mergeResource(base Resource, overlay Resource) Resource {
+	if overlay.ServiceNamespace != "" {
+		base.ServiceNamespace = overlay.ServiceNamespace
+	}
+	if overlay.ServiceName != "" {
+		base.ServiceName = overlay.ServiceName
+	}
+	if overlay.ServiceInstanceID != "" {
+		base.ServiceInstanceID = overlay.ServiceInstanceID
+	}
+	if overlay.ServiceVersion != "" {
+		base.ServiceVersion = overlay.ServiceVersion
+	}
+	if overlay.DeploymentEnvironment != "" {
+		base.DeploymentEnvironment = overlay.DeploymentEnvironment
+	}
+	if overlay.CloudRegion != "" {
+		base.CloudRegion = overlay.CloudRegion
+	}
+	if overlay.CloudAvailabilityZone != "" {
+		base.CloudAvailabilityZone = overlay.CloudAvailabilityZone
+	}
+	if overlay.K8sClusterName != "" {
+		base.K8sClusterName = overlay.K8sClusterName
+	}
+	if overlay.K8sNamespaceName != "" {
+		base.K8sNamespaceName = overlay.K8sNamespaceName
+	}
+	if overlay.DoxOrganization != "" {
+		base.DoxOrganization = overlay.DoxOrganization
+	}
+	if overlay.DoxApplication != "" {
+		base.DoxApplication = overlay.DoxApplication
+	}
+	if overlay.DoxRuntime != "" {
+		base.DoxRuntime = overlay.DoxRuntime
+	}
+	return base
+}
+
+func mergeEvent(base Event, overlay Event) Event {
+	if overlay.Name != "" {
+		base.Name = overlay.Name
+	}
+	if overlay.Dataset != "" {
+		base.Dataset = overlay.Dataset
+	}
+	if overlay.Category != "" {
+		base.Category = overlay.Category
+	}
+	if overlay.Type != "" {
+		base.Type = overlay.Type
+	}
+	if overlay.Action != "" {
+		base.Action = overlay.Action
+	}
+	if overlay.Outcome != "" {
+		base.Outcome = overlay.Outcome
+	}
+	return base
+}
+
+func mergeNode(base Node, overlay Node) Node {
+	if overlay.Component != "" {
+		base.Component = overlay.Component
+	}
+	if overlay.Operation != "" {
+		base.Operation = overlay.Operation
+	}
+	return base
+}
+
+func copyTags(tags Tags) Tags {
+	if tags == nil {
+		return nil
+	}
+	copied := make(Tags, len(tags))
+	for key, value := range tags {
+		copied[key] = value
+	}
+	return copied
+}
+
+func copyFields(fields Fields) Fields {
+	if fields == nil {
+		return nil
+	}
+	copied := make(Fields, len(fields))
+	for key, value := range fields {
+		copied[key] = value
+	}
+	return copied
+}
+
+func sortedTags(tags Tags) Tags {
+	if len(tags) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(tags))
+	for key := range tags {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	sorted := make(Tags, len(tags))
+	for _, key := range keys {
+		sorted[key] = tags[key]
+	}
+	return sorted
+}
+
+func sortedFields(fields Fields) Fields {
+	if len(fields) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	sorted := make(Fields, len(fields))
+	for _, key := range keys {
+		sorted[key] = fields[key]
+	}
+	return sorted
+}

--- a/packages/shared/logging/logger_test.go
+++ b/packages/shared/logging/logger_test.go
@@ -1,0 +1,260 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : logger_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-27
+ * @Modified: 2026-04-27
+ */
+
+package logging
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNewLoggerWritesDoxModelFieldsAndContextCorrelation(t *testing.T) {
+	tempDir := t.TempDir()
+	jsonPath := filepath.Join(tempDir, "service.jsonl")
+
+	base, err := NewZapCoreBase(Config{
+		Zap: ZapConfig{
+			DisableCaller:       true,
+			DisableStacktrace:   true,
+			DisableErrorVerbose: true,
+			ErrorOutputPaths:    []string{filepath.Join(tempDir, "errors.log")},
+		},
+		Cores: []CoreConfig{
+			{
+				Name:        "service-file",
+				Enabled:     boolPtr(true),
+				Type:        CoreTypeFile,
+				Level:       LevelInfo,
+				Encoding:    EncodingJSON,
+				OutputPaths: []string{jsonPath},
+				Datasets:    []string{"*"},
+				Rotation: RotationConfig{
+					Driver: RotationDriverNone,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("build zap core base: %v", err)
+	}
+	t.Cleanup(base.Close)
+
+	logger, err := NewLogger(
+		base,
+		ResourceAttr(Resource{
+			ServiceNamespace:      "dox",
+			ServiceName:           "iam",
+			ServiceInstanceID:     "server-01",
+			ServiceVersion:        "0.1.0",
+			DeploymentEnvironment: "test",
+			DoxRuntime:            "server",
+		}),
+		NodeAttr(Node{
+			Component: "auth_service",
+			Operation: "verify_credential",
+		}),
+		TagsAttr(Tags{
+			"risk_level":   "medium",
+			"login_method": "password",
+		}),
+	)
+	if err != nil {
+		t.Fatalf("build logger facade: %v", err)
+	}
+
+	ctx := ContextWithMergedCorrelation(nil, Correlation{
+		TraceID:       "trace_ctx",
+		RequestID:     "req_ctx",
+		CorrelationID: "corr_ctx",
+	})
+	ctx = ContextWithMergedCorrelation(ctx, Correlation{
+		SpanID: "span_ctx",
+	})
+
+	logger = logger.Named("iam.auth").With(EventAttr(Event{
+		Dataset:  "dox.iam.security",
+		Category: "authentication",
+		Action:   "login",
+	}))
+	logger.Info(
+		ctx,
+		"login rejected",
+		EventAttr(Event{
+			Name:    "iam.login.rejected",
+			Type:    "denied",
+			Outcome: "failure",
+		}),
+		CorrelationAttr(Correlation{
+			CorrelationID: "corr_call",
+		}),
+		FieldsAttr(Fields{
+			"account": "alice@example.com",
+		}),
+		FieldAttr("tenant_id", "tenant_a"),
+		ErrorAttr(errors.New("invalid password")),
+	)
+	if err := logger.Sync(); err != nil {
+		t.Fatalf("sync logger: %v", err)
+	}
+	base.Close()
+
+	entries := readJSONLines(t, jsonPath)
+	if len(entries) != 1 {
+		t.Fatalf("expected one log entry, got %#v", entries)
+	}
+	entry := entries[0]
+
+	for key, expected := range map[string]string{
+		"logger":                       "iam.auth",
+		"message":                      "login rejected",
+		FieldServiceNamespace:          "dox",
+		FieldServiceName:               "iam",
+		FieldServiceInstanceID:         "server-01",
+		FieldServiceVersion:            "0.1.0",
+		FieldDeploymentEnvironmentName: "test",
+		FieldDoxRuntime:                "server",
+		FieldTraceID:                   "trace_ctx",
+		FieldSpanID:                    "span_ctx",
+		FieldRequestID:                 "req_ctx",
+		FieldCorrelationID:             "corr_call",
+		FieldEventName:                 "iam.login.rejected",
+		FieldEventDataset:              "dox.iam.security",
+		FieldEventCategory:             "authentication",
+		FieldEventType:                 "denied",
+		FieldEventAction:               "login",
+		FieldEventOutcome:              "failure",
+		FieldComponent:                 "auth_service",
+		FieldOperation:                 "verify_credential",
+		"error":                        "invalid password",
+	} {
+		if entry[key] != expected {
+			t.Fatalf("expected %s=%q, got %#v in %#v", key, expected, entry[key], entry)
+		}
+	}
+	if _, exists := entry["errorVerbose"]; exists {
+		t.Fatalf("expected disable_error_verbose to suppress errorVerbose, got %#v", entry)
+	}
+
+	tags, ok := entry[FieldTags].(map[string]any)
+	if !ok {
+		t.Fatalf("expected tags object, got %#v", entry[FieldTags])
+	}
+	if tags["risk_level"] != "medium" || tags["login_method"] != "password" {
+		t.Fatalf("expected tags to map, got %#v", tags)
+	}
+
+	fields, ok := entry[FieldFields].(map[string]any)
+	if !ok {
+		t.Fatalf("expected fields object, got %#v", entry[FieldFields])
+	}
+	if fields["account"] != "alice@example.com" || fields["tenant_id"] != "tenant_a" {
+		t.Fatalf("expected fields to map, got %#v", fields)
+	}
+}
+
+func TestContextCorrelationHelpersStoreMergeAndRetrieve(t *testing.T) {
+	if _, ok := CorrelationFromContext(nil); ok {
+		t.Fatal("expected nil context to have no correlation")
+	}
+
+	ctx := ContextWithCorrelation(nil, Correlation{
+		TraceID:   "trace_1",
+		RequestID: "req_1",
+	})
+	correlation, ok := CorrelationFromContext(ctx)
+	if !ok {
+		t.Fatal("expected stored correlation")
+	}
+	if correlation.TraceID != "trace_1" || correlation.RequestID != "req_1" {
+		t.Fatalf("expected stored correlation, got %+v", correlation)
+	}
+
+	ctx = ContextWithMergedCorrelation(ctx, Correlation{
+		RequestID: "req_2",
+		TaskID:    "task_1",
+	})
+	correlation, ok = CorrelationFromContext(ctx)
+	if !ok {
+		t.Fatal("expected merged correlation")
+	}
+	if correlation.TraceID != "trace_1" || correlation.RequestID != "req_2" || correlation.TaskID != "task_1" {
+		t.Fatalf("expected merged correlation, got %+v", correlation)
+	}
+
+	merged := MergeCorrelation(Correlation{
+		TraceID: "trace_base",
+		JobID:   "job_base",
+	}, Correlation{
+		TraceID:     "trace_overlay",
+		PluginRunID: "plugin_run_1",
+	})
+	if merged.TraceID != "trace_overlay" || merged.JobID != "job_base" || merged.PluginRunID != "plugin_run_1" {
+		t.Fatalf("expected explicit merge semantics, got %+v", merged)
+	}
+}
+
+func TestNewLoggerRejectsNilCoreBase(t *testing.T) {
+	if _, err := NewLogger(nil); err == nil {
+		t.Fatal("expected nil zap core base to be rejected")
+	}
+}
+
+func TestLoggerFacadeSignaturesDoNotExposeZapTypes(t *testing.T) {
+	loggerType := reflect.TypeOf((*Logger)(nil)).Elem()
+	for methodIndex := 0; methodIndex < loggerType.NumMethod(); methodIndex++ {
+		method := loggerType.Method(methodIndex)
+		for inputIndex := 0; inputIndex < method.Type.NumIn(); inputIndex++ {
+			assertNoZapType(t, method.Name, method.Type.In(inputIndex))
+		}
+		for outputIndex := 0; outputIndex < method.Type.NumOut(); outputIndex++ {
+			assertNoZapType(t, method.Name, method.Type.Out(outputIndex))
+		}
+	}
+}
+
+func assertNoZapType(t *testing.T, method string, typ reflect.Type) {
+	t.Helper()
+	if typ == nil {
+		return
+	}
+	if strings.HasPrefix(typ.PkgPath(), "go.uber.org/zap") {
+		t.Fatalf("logger method %s exposes zap type %s", method, typ)
+	}
+	switch typ.Kind() {
+	case reflect.Pointer, reflect.Slice, reflect.Array:
+		assertNoZapType(t, method, typ.Elem())
+	case reflect.Map:
+		assertNoZapType(t, method, typ.Key())
+		assertNoZapType(t, method, typ.Elem())
+	case reflect.Func:
+		for index := 0; index < typ.NumIn(); index++ {
+			assertNoZapType(t, method, typ.In(index))
+		}
+		for index := 0; index < typ.NumOut(); index++ {
+			assertNoZapType(t, method, typ.Out(index))
+		}
+	}
+}


### PR DESCRIPTION
## Description

Adds the Dox-owned logger facade and context correlation helpers on top of the shared zap core base. Business code can now depend on `logging.Logger`, `logging.Attr`, and Dox logging model types instead of zap APIs.

## Related Links

- Closes #32
- Refs #26
- Refs #28
- Refs #30

## Scope

- [ ] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [ ] Security
- [x] Backend

## Implementation Notes

- Adds `Logger` with debug, info, warn, error, dpanic, panic, fatal, named, with, and sync methods.
- Adds Dox-owned `Attr` constructors for resource, correlation, event, node, tags, fields, individual fields, and errors.
- Converts Dox model values into zap fields internally while keeping zap out of business-facing logger method signatures.
- Adds context helpers to store, merge, and retrieve `Correlation` values safely with nil contexts.
- Keeps runtime wiring, HTTP middleware, OpenTelemetry SDK setup, redaction processing, and EDA modeling outside this issue.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands run:

```sh
go test -count=1 ./packages/shared/logging
go test -count=1 ./packages/shared/... ./server/...
git diff --check
git verify-commit HEAD
```

## Risks

This PR exposes the shared logger facade only. Server bootstrap, HTTP correlation middleware, IAM samples, scheduler, collector, compute, and OpenTelemetry SDK integration remain follow-up issues.
