### PR TITLE
gh-36 [feat]: Integrate logging config into server settings

### DIFF
--- a/server/internal/setting/README.md
+++ b/server/internal/setting/README.md
@@ -32,6 +32,7 @@ Shared packages provide reusable configuration fragments. This package decides h
 - `server/internal/bootstrap` loads source snapshots from files and environment variables.
 - `packages/shared/config` provides source loading, merging, and decoding primitives.
 - `packages/shared/setting` defines reusable setting fragments.
+- `packages/shared/logging` defines the shared logging model and runtime helper configuration.
 - `server/internal/setting` defines the server runtime aggregate and group-level semantics.
 
 Bootstrap should not own concrete HTTP, database, identity, logging, or security setting structs. It should continue to provide loaded values and diagnostics.
@@ -42,13 +43,15 @@ Use one file per configuration group:
 
 - `setting.go` defines the root `Setting` aggregate.
 - `identity.go` defines the identity group.
-- Future `database.go`, `http.go`, `logging.go`, `security.go`, and similar files should define their own focused groups.
+- `logging.go` defines the server logging configuration group backed by shared logging config.
+- Future `database.go`, `http.go`, `security.go`, and similar files should define their own focused groups.
 
 The root aggregate should compose groups instead of flattening every field:
 
 ```go
 type Setting struct {
     Identity Identity `json:"identity" yaml:"identity" mapstructure:"identity"`
+    Logging  Logging  `json:"logging" yaml:"logging" mapstructure:"logging"`
     Database Database `json:"database" yaml:"database" mapstructure:"database"`
 }
 ```
@@ -68,3 +71,11 @@ The identity group composes shared identity fragments:
 The server package defaults `System.Runtime` to `server`. That default does not belong in `packages/shared/setting`, because scheduler, collector, and compute runtimes must own their own runtime identity.
 
 `Deployment.Env` may be seeded from the bootstrap environment when the final server setting is created. If no seed or explicit value is provided, it falls back to the shared deployment default.
+
+## Logging
+
+The logging group is backed by `packages/shared/logging.Config`.
+
+Server settings own loading, defaulting, and validation of this group. Runtime bootstrap will later decide how to construct zap cores, the Dox logger facade, and OpenTelemetry providers from the validated config.
+
+This package must not open logging sinks, create log files, install OpenTelemetry globals, or wire HTTP/server modules to logging.

--- a/server/internal/setting/logging.go
+++ b/server/internal/setting/logging.go
@@ -15,17 +15,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
- * @File    : doc.go
+ * @File    : logging.go
  * @Author  : Frost Leo <frostleo.dev@gmail.com>
- * @Created : 2026-04-26
- * @Modified: 2026-04-26
+ * @Created : 2026-04-27
+ * @Modified: 2026-04-27
  */
 
-// Package setting defines the concrete configuration aggregate for the Dox
-// Web backend runtime.
-//
-// Shared packages define reusable fragments. This package owns the server
-// runtime composition, defaulting order, and server-specific validation rules.
-// It loads logging configuration but does not initialize runtime loggers,
-// sinks, or OpenTelemetry providers.
 package setting
+
+import sharedlogging "github.com/opendox/dox/packages/shared/logging"
+
+// Logging is the shared logging configuration group accepted by the server.
+//
+// The server setting package loads and validates this group only. Runtime
+// bootstrap owns logger and OpenTelemetry provider initialization in later
+// integration issues.
+type Logging = sharedlogging.Config

--- a/server/internal/setting/setting.go
+++ b/server/internal/setting/setting.go
@@ -33,6 +33,7 @@ type DefaultOptions struct {
 // Setting is the root configuration aggregate for the Dox Web backend runtime.
 type Setting struct {
 	Identity Identity `json:"identity" yaml:"identity" mapstructure:"identity"`
+	Logging  Logging  `json:"logging" yaml:"logging" mapstructure:"logging"`
 }
 
 // Default fills stable server defaults without bootstrap-derived values.
@@ -45,12 +46,21 @@ func (s *Setting) DefaultWithOptions(options DefaultOptions) error {
 	if s == nil {
 		return errors.New("server setting: setting must not be nil")
 	}
-	return s.Identity.DefaultWithOptions(IdentityDefaultOptions{
+	if err := s.Identity.DefaultWithOptions(IdentityDefaultOptions{
 		Env: options.Env,
-	})
+	}); err != nil {
+		return err
+	}
+	if err := s.Logging.Default(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // Validate verifies the concrete server configuration aggregate.
 func (s Setting) Validate() error {
-	return s.Identity.Validate()
+	return errors.Join(
+		s.Identity.Validate(),
+		s.Logging.Validate(),
+	)
 }

--- a/server/internal/setting/setting_test.go
+++ b/server/internal/setting/setting_test.go
@@ -25,13 +25,17 @@ package setting
 
 import (
 	"context"
+	"errors"
+	"os"
 	"testing"
+	"time"
 
 	sharedconfig "github.com/opendox/dox/packages/shared/config"
+	sharedlogging "github.com/opendox/dox/packages/shared/logging"
 	sharedsetting "github.com/opendox/dox/packages/shared/setting"
 )
 
-func TestSettingDefaultAppliesIdentityDefaults(t *testing.T) {
+func TestSettingDefaultAppliesIdentityAndLoggingDefaults(t *testing.T) {
 	setting := Setting{}
 
 	if err := setting.DefaultWithOptions(DefaultOptions{Env: "test"}); err != nil {
@@ -42,6 +46,18 @@ func TestSettingDefaultAppliesIdentityDefaults(t *testing.T) {
 	}
 	if setting.Identity.Deployment.Env != sharedsetting.EnvTest {
 		t.Fatalf("expected deployment env from options, got %q", setting.Identity.Deployment.Env)
+	}
+	if setting.Logging.Level != sharedlogging.LevelInfo {
+		t.Fatalf("expected logging level info, got %q", setting.Logging.Level)
+	}
+	if len(setting.Logging.Cores) != 2 {
+		t.Fatalf("expected logging default cores, got %#v", setting.Logging.Cores)
+	}
+	if setting.Logging.Shutdown.Timeout != 5*time.Second {
+		t.Fatalf("expected logging shutdown timeout 5s, got %s", setting.Logging.Shutdown.Timeout)
+	}
+	if setting.Logging.OTel.Exporter.OTLP.Enabled {
+		t.Fatal("expected logging OTLP exporter to be disabled by default")
 	}
 	if err := setting.Validate(); err != nil {
 		t.Fatalf("validate setting: %v", err)
@@ -70,6 +86,32 @@ func TestSettingDecodeValuesSupportsNestedIdentity(t *testing.T) {
 				"k8s_namespace": "dox-prod",
 			},
 		},
+		"logging": map[string]any{
+			"level": "debug",
+			"zap": map[string]any{
+				"level": "warn",
+				"encoder_config": map[string]any{
+					"level_encoder":    "capital",
+					"time_encoder":     "rfc3339nano",
+					"duration_encoder": "millis",
+					"caller_encoder":   "short",
+					"name_encoder":     "full",
+				},
+				"output_paths":       []any{"stdout"},
+				"error_output_paths": []any{"stderr"},
+			},
+			"shutdown": map[string]any{
+				"timeout": "2s",
+			},
+			"otel": map[string]any{
+				"traces": map[string]any{
+					"sampler": map[string]any{
+						"type":  "traceidratio",
+						"ratio": 0.25,
+					},
+				},
+			},
+		},
 	}
 
 	setting := Setting{}
@@ -94,6 +136,18 @@ func TestSettingDecodeValuesSupportsNestedIdentity(t *testing.T) {
 	}
 	if setting.Identity.Deployment.Env != sharedsetting.EnvProd {
 		t.Fatalf("expected deployment env from bootstrap option, got %q", setting.Identity.Deployment.Env)
+	}
+	if setting.Logging.Level != sharedlogging.LevelDebug {
+		t.Fatalf("expected decoded logging level debug, got %q", setting.Logging.Level)
+	}
+	if setting.Logging.Zap.Level != sharedlogging.LevelWarn {
+		t.Fatalf("expected decoded zap logging level warn, got %q", setting.Logging.Zap.Level)
+	}
+	if setting.Logging.Shutdown.Timeout != 2*time.Second {
+		t.Fatalf("expected decoded logging shutdown timeout 2s, got %s", setting.Logging.Shutdown.Timeout)
+	}
+	if setting.Logging.OTel.Traces.Sampler.Ratio != 0.25 {
+		t.Fatalf("expected decoded logging sampler ratio 0.25, got %f", setting.Logging.OTel.Traces.Sampler.Ratio)
 	}
 }
 
@@ -122,6 +176,32 @@ func TestSettingValidateRejectsInvalidDecodedIdentity(t *testing.T) {
 	}
 }
 
+func TestSettingValidateRejectsInvalidLogging(t *testing.T) {
+	setting := Setting{}
+
+	if err := setting.Default(); err != nil {
+		t.Fatalf("default setting: %v", err)
+	}
+	setting.Logging.Level = sharedlogging.Level("verbose")
+
+	if err := setting.Validate(); !hasLoggingValidationField(err, "level") {
+		t.Fatalf("expected invalid logging level validation error, got %v", err)
+	}
+}
+
+func TestSettingDefaultDoesNotInitializeLoggingRuntime(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	setting := Setting{}
+	if err := setting.Default(); err != nil {
+		t.Fatalf("default setting: %v", err)
+	}
+
+	if _, err := os.Stat("logs"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected setting defaults not to create logs directory, got %v", err)
+	}
+}
+
 func TestSettingValidateRejectsInvalidBootstrapEnv(t *testing.T) {
 	setting := Setting{}
 
@@ -139,4 +219,17 @@ func TestSettingDefaultRejectsNilReceiver(t *testing.T) {
 	if err := setting.Default(); err == nil {
 		t.Fatal("expected nil setting default error")
 	}
+}
+
+func hasLoggingValidationField(err error, field string) bool {
+	var validationErr *sharedlogging.ValidationError
+	if !errors.As(err, &validationErr) {
+		return false
+	}
+	for _, item := range validationErr.Fields {
+		if item.Field == field {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Description

Integrates the shared logging configuration into the server setting aggregate. Server settings can now decode, default, and validate a nested `logging` group backed by `packages/shared/logging.Config`.

This PR intentionally stops at configuration loading and validation. It does not initialize zap, open file sinks, install OpenTelemetry globals, or wire logging into server runtime behavior.

## Related Links

- Closes #36
- Refs #34

## Scope

- [ ] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [ ] Security

## Implementation Notes

- Adds `server/internal/setting.Logging` as an alias for `packages/shared/logging.Config`.
- Adds `Logging` to the root server `Setting` aggregate with JSON/YAML/mapstructure tags.
- Applies shared logging defaults and validation through `Setting.DefaultWithOptions` and `Setting.Validate`.
- Extends server setting tests for nested logging decode, invalid logging validation, and no runtime side effects.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands:

```sh
env GOROOT=/home/frost/workspace/.tools/go1.25.6 GOPATH=/home/frost/workspace/.gopath GOCACHE=/home/frost/workspace/.cache/go-build GOPROXY=off PATH=/home/frost/workspace/.tools/go1.25.6/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin go test -count=1 ./packages/shared/... ./server/...
```

## Risks

Runtime logging initialization is intentionally not included. A follow-up bootstrap issue still needs to construct zap cores, the Dox logger facade, and OpenTelemetry providers from the validated setting.
