### PR TITLE
gh-38 [docs]: Add shared config package handbook

### DIFF
--- a/docs/en-us/handbook/shared-packages/config/README.md
+++ b/docs/en-us/handbook/shared-packages/config/README.md
@@ -1,0 +1,158 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/en-us/handbook/shared-packages/config/README.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Config Package Handbook
+
+`packages/shared/config` is the shared Dox configuration loading SDK. It gives each backend runtime an explicit way to read declared sources, parse source payloads, merge values, decode into caller-owned targets, and return operational diagnostics.
+
+This handbook is written for developers and coding agents. Treat it as the package-level contract for consumers in Web, Scheduling, Collection, Computation, and any later runtime that imports `github.com/opendox/dox/packages/shared/config`.
+
+## Table of Contents
+
+- [Contract](contract.md): request, source, option, result, diagnostics, and error semantics.
+- [Pipeline](pipeline.md): provider, parser, merge, decode, fingerprint, and diagnostics flow.
+- [Functions and API](functions.md): exported entry points, interfaces, helpers, and caller obligations.
+
+## Package Position
+
+The package owns the loading pipeline contract. It validates API usage before work starts, executes the pipeline for one explicit `Request`, and returns a `Result` that callers can log or inspect.
+
+The package does not own runtime-specific setting validation. Runtime packages define their own setting structs, field constraints, default policy, and operational rules after this package has decoded raw configuration values.
+
+## Current Capability
+
+The current implementation includes:
+
+- local file and environment providers;
+- YAML, JSON, TOML, and `none` parsers;
+- deep map merge with scalar and slice replacement;
+- source ordering by ascending `Priority`;
+- environment dotted-key expansion before merge;
+- decode into struct pointers or map pointers through `mapstructure`;
+- reject-by-default unknown key handling;
+- stable `sha256:` fingerprints over merged values;
+- source diagnostics and override diagnostics;
+- extension points for custom providers, parsers, mergers, and decoders.
+
+`ProviderKindRemote` exists as a named kind, but no remote provider is registered by the default loader. Callers must register a provider before using remote or other custom source kinds.
+
+## Current Non-capability
+
+The package currently does not implement:
+
+- runtime-specific setting validation;
+- file watching or hot reload;
+- remote provider reads in the default loader;
+- default file path discovery;
+- secret loading;
+- schema generation;
+- value redaction enforcement for `Options.RedactKeys`.
+
+`Options.RedactKeys` is accepted as part of the option shape, but the current pipeline does not apply redaction to values, diagnostics, errors, or fingerprints. Do not treat it as a sanitization guarantee.
+
+## Basic Usage
+
+```go
+package runtime
+
+import (
+	"context"
+	"time"
+
+	sharedconfig "github.com/opendox/dox/packages/shared/config"
+)
+
+type Setting struct {
+	App struct {
+		Name string `mapstructure:"name"`
+	} `mapstructure:"app"`
+	HTTP struct {
+		Port    int           `mapstructure:"port"`
+		Timeout time.Duration `mapstructure:"timeout"`
+	} `mapstructure:"http"`
+}
+
+func LoadSetting(ctx context.Context, basePath string) (*Setting, *sharedconfig.Result, error) {
+	var target Setting
+	result, err := sharedconfig.Load(ctx, sharedconfig.Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []sharedconfig.Source{
+			{
+				Name:     "base",
+				Kind:     sharedconfig.ProviderKindFile,
+				Parser:   sharedconfig.ParserKindYAML,
+				Location: basePath,
+				Required: true,
+				Priority: 10,
+			},
+			{
+				Name:     "env",
+				Kind:     sharedconfig.ProviderKindEnv,
+				Parser:   sharedconfig.ParserKindNone,
+				Location: "DOX_SERVER_",
+				Required: false,
+				Priority: 100,
+			},
+		},
+		Options: sharedconfig.Options{
+			UnknownKeyPolicy: sharedconfig.UnknownKeyPolicyReject,
+		},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return &target, result, nil
+}
+```
+
+This example reads a required YAML file first, then applies matching environment variables as higher-priority overrides. The caller still owns setting defaults, domain validation, and runtime startup behavior.
+
+## Consumer Rules
+
+Consumers should:
+
+- create a typed setting target owned by the runtime package;
+- declare every source explicitly;
+- use unique source names and unique priorities;
+- keep lower-priority base files before higher-priority overrides;
+- use `ParserKindNone` for environment sources;
+- inspect typed errors with `IsKind`;
+- persist or log `Result.SourceNames`, `Result.Fingerprint`, and diagnostics when operational traceability is needed.
+
+Consumers should not:
+
+- rely on undeclared default sources;
+- pass a nil context or nil target;
+- use `ProviderKindRemote` without registering a provider;
+- expose Koanf or mapstructure as part of their own public runtime contract;
+- assume `RedactKeys` removes sensitive values.
+
+## Reading Order
+
+Read these pages in order when implementing a new runtime integration:
+
+1. [Contract](contract.md) to understand valid requests and failure classes.
+2. [Pipeline](pipeline.md) to understand how values move and override each other.
+3. [Functions and API](functions.md) to choose the entry point and extension points.

--- a/docs/en-us/handbook/shared-packages/config/contract.md
+++ b/docs/en-us/handbook/shared-packages/config/contract.md
@@ -1,0 +1,156 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/en-us/handbook/shared-packages/config/contract.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Config Contract
+
+The config package contract is centered on one explicit `Request`. A caller provides runtime identity, environment identity, a target pointer, ordered source descriptors, and options. The loader validates that contract before reading sources.
+
+## Request Contract
+
+| Field | Required | Semantics |
+| --- | --- | --- |
+| `Runtime` | Yes | Lowercase runtime name. It must start with a letter and may contain lowercase letters, digits, and hyphens. |
+| `Env` | Yes | Lowercase environment name. It follows the same naming rule as `Runtime`. |
+| `Target` | Yes | Non-nil pointer to a struct or map. The caller owns the target type and later validation. |
+| `Sources` | Usually | Source list to read. Empty sources are rejected unless `Options.AllowEmptySources` is true. |
+| `Options` | No | Pipeline behavior. Empty options are normalized to package defaults. |
+
+The package validates request shape only. It does not validate domain-specific setting values such as ports, business toggles, tenant policy, or runtime deployment rules.
+
+## Source Contract
+
+Each `Source` declares one provider read.
+
+| Field | Required | Semantics |
+| --- | --- | --- |
+| `Name` | Yes | Unique source name. It must start with a letter and may contain lowercase letters, digits, hyphens, underscores, and dots. |
+| `Kind` | Yes | Provider kind. Built-in kinds are `file` and `env`; custom names are accepted by validation but must be registered before loading. |
+| `Parser` | Yes | Parser kind. Built-in kinds are `yaml`, `json`, `toml`, and `none`; custom names are accepted by validation but must be registered before loading. |
+| `Location` | Yes | Provider-specific location. For files this is a filesystem path. For env sources this is the required variable prefix. |
+| `Required` | No | Required sources fail when unreadable or missing. Optional missing file/env sources are skipped with diagnostics. |
+| `Priority` | No | Non-negative merge priority. Lower numbers merge first; later higher-priority sources override earlier values. Priorities must be unique. |
+| `Options` | No | Provider-specific string options. The current built-in providers do not consume source options. |
+
+Provider and parser compatibility is part of the request contract:
+
+- `ProviderKindEnv` must use `ParserKindNone`.
+- `ProviderKindFile` must use a parser other than `ParserKindNone`.
+- Custom provider and parser kinds must pass naming validation and must be registered in `LoaderConfig` before load time.
+
+## Built-in Kinds
+
+| Kind | Value | Registered by default | Notes |
+| --- | --- | --- | --- |
+| `ProviderKindFile` | `file` | Yes | Reads local files as raw bytes. |
+| `ProviderKindEnv` | `env` | Yes | Reads environment variables by prefix and returns structured dotted keys. |
+| `ProviderKindRemote` | `remote` | No | Named for future or custom use. The default loader does not read remote sources. |
+| `ParserKindNone` | `none` | Yes | Returns provider values without raw parsing. Used by env sources. |
+| `ParserKindYAML` | `yaml` | Yes | Parses YAML object payloads. |
+| `ParserKindJSON` | `json` | Yes | Parses JSON object payloads and preserves JSON numbers. |
+| `ParserKindTOML` | `toml` | Yes | Parses TOML object payloads. |
+
+## Option Contract
+
+| Field | Default | Semantics |
+| --- | --- | --- |
+| `AllowEmptySources` | `false` | Allows an empty source list when true. |
+| `MergeStrategy` | `deep_replace` | Only `MergeStrategyDeepReplace` is currently supported. |
+| `UnknownKeyPolicy` | `reject` | `reject` fails on unused decoded keys. `allow` ignores unknown keys. |
+| `Timeout` | `0` | When positive, applies one context timeout to the full load operation. Negative durations are invalid. |
+| `RedactKeys` | Empty | Accepted but not enforced by the current implementation. |
+
+Unsupported merge strategies and unknown-key policies fail with `ErrorKindContract`.
+
+## Result Contract
+
+`Result` is returned only after a successful load and decode.
+
+| Field | Semantics |
+| --- | --- |
+| `Runtime` | Copied from the request. |
+| `Env` | Copied from the request. |
+| `SourceNames` | Source names after priority ordering. Skipped optional sources are still represented. |
+| `Fingerprint` | `sha256:` fingerprint computed from the merged value map after decode succeeds. |
+| `Diagnostics` | Source participation and override diagnostics. |
+
+The fingerprint is computed from the merged structured values. It is not a secret-safe digest contract, because the current implementation does not apply `RedactKeys`.
+
+## Diagnostics Contract
+
+`Diagnostics.Sources` records how each source participated in the merge.
+
+| Field | Semantics |
+| --- | --- |
+| `Name` | Source name. |
+| `Kind` | Provider kind. |
+| `Required` | Required flag from the source. |
+| `Loaded` | True when provider data was loaded or merge inferred loaded values. |
+| `Skipped` | True when an optional missing source was skipped. |
+| `Message` | Human-readable context for skip or provider status. |
+
+`Diagnostics.Overrides` records value replacement events.
+
+| Field | Semantics |
+| --- | --- |
+| `Path` | Dot path that was replaced. |
+| `Source` | Source that supplied the replacing value. |
+| `PreviousSource` | Earlier source that supplied the previous value. |
+
+Nested maps are deep-merged. Scalars and slices are replaced. Override diagnostics are recorded when a later source changes a previously owned path.
+
+## Error Contract
+
+All package-classified errors use `*config.Error`.
+
+| Kind | Meaning |
+| --- | --- |
+| `ErrorKindContract` | The caller violated API or request rules. |
+| `ErrorKindSource` | A provider could not read a declared source. |
+| `ErrorKindParse` | A parser could not convert source payload data. |
+| `ErrorKindMerge` | Parsed source values could not be merged. |
+| `ErrorKindDecode` | Merged values could not be decoded into the target. |
+
+Use `IsKind(err, kind)` or `errors.Is(err, &config.Error{Kind: kind})` instead of parsing error strings. Error strings are human-readable but should not be treated as machine contracts.
+
+## Extension Contract
+
+The package supports custom pipeline components through `LoaderConfig`:
+
+- `Providers` registers additional `ProviderKind` handlers or overrides built-ins.
+- `Parsers` registers additional `ParserKind` handlers or overrides built-ins.
+- `Merger` replaces the default deep-replace merger.
+- `Decoder` replaces the default mapstructure decoder.
+
+Custom components must preserve the public semantics expected by the caller. The default loader will still validate request shape before invoking custom providers and parsers.
+
+## Out of Contract
+
+The following behavior is outside this package contract:
+
+- runtime-specific setting defaults and validation;
+- selecting source lists from process flags, deployment manifests, or service discovery;
+- remote reads unless a caller registers and owns the provider;
+- hot reload and watcher lifecycle;
+- secret resolution;
+- redacting returned values or diagnostics;
+- guaranteeing Koanf or mapstructure behavior as a public runtime API.

--- a/docs/en-us/handbook/shared-packages/config/functions.md
+++ b/docs/en-us/handbook/shared-packages/config/functions.md
@@ -1,0 +1,175 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/en-us/handbook/shared-packages/config/functions.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Config Functions and API
+
+This page lists the exported API surface that package consumers can rely on. It is not a replacement for Go documentation, but it explains how each exported symbol fits into the package contract.
+
+## Load Entry Points
+
+| API | Purpose | Use When |
+| --- | --- | --- |
+| `Load(ctx, req)` | Runs a request through a new default loader. | The runtime only needs built-in file/env providers and YAML/JSON/TOML/none parsers. |
+| `NewDefaultLoader()` | Creates a default loader with built-in components. | The runtime wants a reusable loader instance without custom components. |
+| `NewLoader(LoaderConfig)` | Creates a loader with built-ins plus overrides. | The runtime needs custom providers, parsers, merger, or decoder. |
+| `(*DefaultLoader).Load(ctx, req)` | Runs one request through a configured loader. | The runtime already owns a loader instance. |
+
+Use `Load` for simple local integrations. Use `NewLoader` when adding custom source kinds, such as a memory provider in tests or a remote provider owned by a runtime.
+
+## Loader Configuration
+
+| API | Purpose |
+| --- | --- |
+| `Loader` | Interface with `Load(ctx, req) (*Result, error)`. |
+| `DefaultLoader` | Built-in implementation that orchestrates providers, parsers, merger, decoder, and fingerprinting. |
+| `LoaderConfig` | Registers provider/parser maps and optional custom merger/decoder. |
+
+`LoaderConfig.Providers` and `LoaderConfig.Parsers` are additive over built-ins. If a map contains a built-in key, the supplied component replaces that built-in component for the created loader.
+
+## Provider API
+
+| API | Purpose |
+| --- | --- |
+| `Provider` | Interface with `Read(ctx, source) (*Payload, error)`. |
+| `ProviderFunc` | Adapter that lets a function implement `Provider`. |
+| `FileProvider` | Built-in provider for local file reads. |
+| `EnvProvider` | Built-in provider for environment variable prefix reads. |
+| `ProviderKindFile` | Built-in `file` provider kind. |
+| `ProviderKindEnv` | Built-in `env` provider kind. |
+| `ProviderKindRemote` | Named `remote` kind without a default registered provider. |
+
+Provider implementations should return `SourceError` for read failures and `ContractError` for provider/source mismatches. They should not merge, decode, or validate runtime-specific settings.
+
+## Parser API
+
+| API | Purpose |
+| --- | --- |
+| `Parser` | Interface with `Parse(ctx, payload) (map[string]any, error)`. |
+| `ParserFunc` | Adapter that lets a function implement `Parser`. |
+| `NoneParser` | Returns provider values for structured payloads. |
+| `YAMLParser` | Parses YAML object payloads. |
+| `JSONParser` | Parses JSON object payloads. |
+| `TOMLParser` | Parses TOML object payloads. |
+| `BuiltinParser(kind)` | Returns a built-in parser and a boolean. |
+| `ParsePayload(ctx, payload)` | Parses a payload with its declared built-in parser. |
+
+Parser implementations should return `ParseError` for malformed source data. They should return `ContractError` when the payload does not match the parser implementation.
+
+## Merge API
+
+| API | Purpose |
+| --- | --- |
+| `Merger` | Interface with `Merge(ctx, sources, options) (*MergeResult, error)`. |
+| `DeepReplaceMerger` | Built-in merger. Deep-merges maps and replaces scalars/slices. |
+| `MergeParsedSources(ctx, sources, options)` | Convenience helper using `DeepReplaceMerger`. |
+| `ParsedSourceFromPayload(payload, values)` | Binds parsed values back to provider metadata. |
+
+The built-in merger sorts by ascending priority. It records ordered source names, source diagnostics, and override diagnostics.
+
+## Decode API
+
+| API | Purpose |
+| --- | --- |
+| `Decoder` | Interface with `Decode(ctx, values, target, options) error`. |
+| `MapstructureDecoder` | Built-in mapstructure-backed decoder. |
+| `DecodeValues(ctx, values, target, options)` | Convenience helper using `MapstructureDecoder`. |
+| `DecodeMergeResult(ctx, result, target, options)` | Decodes the values from a merge result. |
+
+Decode helpers are useful in tests or in custom pipelines. The full loader should usually be preferred by runtimes because it preserves diagnostics and fingerprinting.
+
+## Validation API
+
+| API | Purpose |
+| --- | --- |
+| `ValidateLoadRequest(ctx, req)` | Validates request shape before loading. |
+
+Use validation directly when a runtime wants to fail fast before constructing a loader or before adding runtime-specific checks. Validation does not prove custom providers or parsers are registered.
+
+## Error API
+
+| API | Purpose |
+| --- | --- |
+| `Error` | Typed package error with `Kind`, `Field`, `Reason`, and wrapped `Err`. |
+| `ErrorKindContract` | API or request contract failure. |
+| `ErrorKindSource` | Source read failure. |
+| `ErrorKindParse` | Source parse failure. |
+| `ErrorKindMerge` | Merge failure. |
+| `ErrorKindDecode` | Decode failure. |
+| `ContractError` | Creates a contract error. |
+| `SourceError` | Creates a source error. |
+| `ParseError` | Creates a parse error. |
+| `MergeError` | Creates a merge error. |
+| `DecodeError` | Creates a decode error. |
+| `IsKind(err, kind)` | Reports whether an error contains a config error of the requested kind. |
+
+Callers should branch on error kind rather than string contents.
+
+## Data Types
+
+| Type | Purpose |
+| --- | --- |
+| `Request` | One load operation. |
+| `Options` | Load, merge, decode, and diagnostics behavior. |
+| `Source` | One provider source descriptor. |
+| `Payload` | Provider output before parser conversion. |
+| `ParsedSource` | Parsed source values with source metadata. |
+| `MergeResult` | Merged values, source names, and diagnostics. |
+| `Result` | Successful load output after decode and fingerprinting. |
+| `Diagnostics` | Source diagnostics and override diagnostics. |
+| `SourceDiagnostic` | One source participation record. |
+| `MergeOverride` | One override record. |
+
+These types are plain Go structs. The package does not hide source shape behind global state.
+
+## Common Recipes
+
+### Default local load
+
+Use `Load(ctx, req)` with file and env sources. This is the normal path for local runtime startup.
+
+### Test-only memory source
+
+Use `NewLoader(LoaderConfig{Providers: ..., Parsers: ...})` with custom kinds and `ProviderFunc` / `ParserFunc`. This keeps tests away from filesystem and process environment state.
+
+### Pre-merge inspection
+
+Use providers, parsers, and `MergeParsedSources` directly only when building a custom runtime pipeline. Most consumers should not need this.
+
+### Decode-only tests
+
+Use `DecodeValues` or `DecodeMergeResult` when testing target struct tags, duration conversion, or unknown-key behavior without source reads.
+
+## Caller Obligations
+
+Every consumer must own:
+
+- setting target type definition;
+- runtime-specific defaults;
+- domain validation after decode;
+- source list selection;
+- environment prefix policy;
+- secret and redaction policy;
+- startup logging policy;
+- any hot reload, remote configuration, or watcher lifecycle.
+
+The shared package gives a deterministic loading primitive. It does not replace runtime configuration design.

--- a/docs/en-us/handbook/shared-packages/config/pipeline.md
+++ b/docs/en-us/handbook/shared-packages/config/pipeline.md
@@ -1,0 +1,181 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/en-us/handbook/shared-packages/config/pipeline.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Config Pipeline
+
+The default loader runs one request through a fixed local pipeline:
+
+```text
+Request
+  -> validate request and normalize options
+  -> apply request timeout when configured
+  -> provider read for each source
+  -> parser parse for each payload
+  -> merge parsed sources by priority
+  -> decode merged values into target
+  -> fingerprint merged values
+  -> return Result
+```
+
+Every stage receives the request context. If `Options.Timeout` is positive, the loader wraps the context with that timeout before provider reads begin.
+
+## Stage 1: Validation
+
+`ValidateLoadRequest` runs before source reads. It checks:
+
+- non-nil context;
+- valid `Runtime` and `Env`;
+- non-nil pointer target to a struct or map;
+- supported option values;
+- source presence unless `AllowEmptySources` is true;
+- unique source names;
+- unique source priorities;
+- valid source names, provider kinds, parser kinds, locations, and priorities;
+- built-in file/env provider and parser compatibility.
+
+Validation accepts custom provider and parser kind names when they follow naming rules. Load will still fail later with `ErrorKindContract` if no matching registered component exists.
+
+## Stage 2: Provider Read
+
+The provider returns a `Payload`. A payload may contain `Raw` bytes, structured `Values`, provider `Metadata`, and a `SourceDiagnostic`.
+
+### File Provider
+
+`FileProvider` reads `Source.Location` from the local filesystem.
+
+- Required missing files fail with `ErrorKindSource`.
+- Optional missing files return a skipped payload.
+- Directories fail with `ErrorKindSource`.
+- Successful reads populate `Raw`, file path metadata, and a loaded diagnostic.
+
+The file provider does not parse bytes. It only reads the source.
+
+### Environment Provider
+
+`EnvProvider` reads environment entries from `Lookup` when provided, otherwise from `os.Environ`.
+
+It filters entries by `Source.Location` as a prefix. Matching keys are normalized by:
+
+- removing the source prefix;
+- trimming leading and trailing underscores;
+- lowercasing;
+- replacing double underscores with dots;
+- replacing remaining underscores with dots.
+
+Examples:
+
+| Environment key | Prefix | Normalized key |
+| --- | --- | --- |
+| `DOX_SERVER_APP_NAME` | `DOX_SERVER_` | `app.name` |
+| `DOX_SERVER_HTTP__ADDRESS` | `DOX_SERVER_` | `http.address` |
+
+When no matching variables exist, a required env source fails with `ErrorKindSource`; an optional env source is skipped with diagnostics.
+
+## Stage 3: Parser
+
+The parser converts one provider payload into `map[string]any`.
+
+| Parser | Input | Behavior |
+| --- | --- | --- |
+| `NoneParser` | `Payload.Values` | Returns a shallow copy. Used for env sources. |
+| `YAMLParser` | `Payload.Raw` | Parses YAML and requires an object root. |
+| `JSONParser` | `Payload.Raw` | Parses JSON, rejects trailing data, preserves numbers as `json.Number`, and requires an object root. |
+| `TOMLParser` | `Payload.Raw` | Parses TOML and requires an object root. |
+
+Skipped optional payloads parse as an empty map. Malformed payloads fail with `ErrorKindParse`. Parser implementation mismatches fail with `ErrorKindContract`.
+
+## Stage 4: Merge
+
+`DeepReplaceMerger` sorts parsed sources by ascending `Source.Priority`. Lower-priority numbers merge first. Higher-priority sources override previous values.
+
+Merge behavior:
+
+- nested maps are deep-merged;
+- scalars replace previous scalars;
+- slices replace previous slices;
+- skipped sources appear in `SourceNames` and source diagnostics but do not change values;
+- duplicate source names or priorities fail with `ErrorKindContract`;
+- environment sources using `ParserKindNone` expand dotted keys into nested maps before merging.
+
+Example:
+
+```text
+base priority 10:
+  app.name = dox
+  http.timeout = 5s
+
+env priority 100:
+  app.name = dox-env
+  http.timeout = 10s
+
+merged:
+  app.name = dox-env
+  http.timeout = 10s
+```
+
+The result records override diagnostics for `app.name` and `http.timeout`, with `env` replacing `base`.
+
+Conflicting environment dotted keys fail with `ErrorKindMerge`. For example, one env source cannot provide both `app=dox` and `app.name=dox` because the same path would need to be both scalar and map.
+
+## Stage 5: Decode
+
+`MapstructureDecoder` decodes merged values into the caller target.
+
+Decode behavior:
+
+- target must be a non-nil pointer to a struct or map;
+- struct tags use `mapstructure`;
+- weak type conversion is enabled;
+- string-to-`time.Duration` conversion is enabled;
+- target fields are zeroed before decode;
+- unknown keys are rejected by default;
+- `UnknownKeyPolicyAllow` permits unknown keys.
+
+Decode failures return `ErrorKindDecode`. Invalid targets return `ErrorKindContract`.
+
+## Stage 6: Fingerprint and Result
+
+After decode succeeds, the loader computes a stable `sha256:` fingerprint from the merged structured value map. The result includes:
+
+- request runtime;
+- request environment;
+- ordered source names;
+- fingerprint;
+- source diagnostics;
+- merge override diagnostics.
+
+The fingerprint represents merged values, not the decoded target. If decode fails, no result is returned.
+
+## Operational Notes
+
+Use source names that reveal intent, such as `base`, `local`, `secrets`, or `env`. Keep priorities sparse, such as `10`, `20`, and `100`, so new override layers can be inserted later.
+
+For deterministic operations:
+
+- avoid duplicate priorities;
+- keep file formats object-rooted;
+- keep env variable prefixes runtime-specific;
+- log source names and fingerprint after successful startup;
+- log diagnostics when investigating override behavior.
+
+Do not log raw merged values unless the caller has already applied its own redaction policy.

--- a/docs/zh-cn/handbook/shared-packages/config/README.md
+++ b/docs/zh-cn/handbook/shared-packages/config/README.md
@@ -1,0 +1,158 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/zh-cn/handbook/shared-packages/config/README.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Config 包手册
+
+`packages/shared/config` 是 Dox 共享的配置加载 SDK。它为各个后端 runtime 提供一套显式流程：读取声明的配置源、解析 payload、合并值、解码到调用方拥有的目标对象，并返回可观察诊断信息。
+
+这份手册面向开发者和编码 Agent。Web、Scheduling、Collection、Computation 以及后续 runtime 引用 `github.com/opendox/dox/packages/shared/config` 时，都应把这里当作包级契约。
+
+## 目录
+
+- [契约](contract.md)：`Request`、`Source`、`Options`、`Result`、诊断和错误语义。
+- [管线](pipeline.md)：provider、parser、merge、decode、fingerprint 和 diagnostics 流程。
+- [函数与 API](functions.md)：导出入口、接口、辅助函数和调用方责任。
+
+## 包定位
+
+这个包负责配置加载管线契约。它在工作开始前验证 API 使用方式，为一个显式 `Request` 执行加载流程，并返回调用方可以记录或检查的 `Result`。
+
+这个包不负责 runtime 级 setting 校验。各 runtime 包在解码出原始配置值后，自己定义 setting 结构体、字段约束、默认策略和运行规则。
+
+## 当前能力
+
+当前实现包含：
+
+- 本地文件 provider 和环境变量 provider；
+- YAML、JSON、TOML 和 `none` parser；
+- map 深度合并，scalar 和 slice 替换；
+- 按 `Priority` 升序排列 source；
+- merge 前展开环境变量 dotted key；
+- 通过 `mapstructure` 解码到 struct pointer 或 map pointer；
+- 默认拒绝未知 key；
+- 基于合并后值的稳定 `sha256:` fingerprint；
+- source diagnostics 和 override diagnostics；
+- 自定义 provider、parser、merger、decoder 的扩展点。
+
+`ProviderKindRemote` 作为命名 kind 已存在，但默认 loader 没有注册 remote provider。调用方要使用 remote 或其他自定义 source kind，必须先注册 provider。
+
+## 当前非能力
+
+这个包当前不实现：
+
+- runtime 级 setting 校验；
+- 文件监听或热重载；
+- 默认 loader 中的 remote provider 读取；
+- 默认文件路径发现；
+- secret 加载；
+- schema 生成；
+- 对 `Options.RedactKeys` 的值脱敏执行。
+
+`Options.RedactKeys` 目前只是 option 结构的一部分，当前管线不会把它应用到 values、diagnostics、errors 或 fingerprints。不要把它当作脱敏保证。
+
+## 基本用法
+
+```go
+package runtime
+
+import (
+	"context"
+	"time"
+
+	sharedconfig "github.com/opendox/dox/packages/shared/config"
+)
+
+type Setting struct {
+	App struct {
+		Name string `mapstructure:"name"`
+	} `mapstructure:"app"`
+	HTTP struct {
+		Port    int           `mapstructure:"port"`
+		Timeout time.Duration `mapstructure:"timeout"`
+	} `mapstructure:"http"`
+}
+
+func LoadSetting(ctx context.Context, basePath string) (*Setting, *sharedconfig.Result, error) {
+	var target Setting
+	result, err := sharedconfig.Load(ctx, sharedconfig.Request{
+		Runtime: "server",
+		Env:     "dev",
+		Target:  &target,
+		Sources: []sharedconfig.Source{
+			{
+				Name:     "base",
+				Kind:     sharedconfig.ProviderKindFile,
+				Parser:   sharedconfig.ParserKindYAML,
+				Location: basePath,
+				Required: true,
+				Priority: 10,
+			},
+			{
+				Name:     "env",
+				Kind:     sharedconfig.ProviderKindEnv,
+				Parser:   sharedconfig.ParserKindNone,
+				Location: "DOX_SERVER_",
+				Required: false,
+				Priority: 100,
+			},
+		},
+		Options: sharedconfig.Options{
+			UnknownKeyPolicy: sharedconfig.UnknownKeyPolicyReject,
+		},
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return &target, result, nil
+}
+```
+
+这个例子先读取一个必需 YAML 文件，再用匹配前缀的环境变量作为更高优先级覆盖。调用方仍然负责 setting 默认值、领域校验和 runtime 启动行为。
+
+## 调用方规则
+
+调用方应该：
+
+- 创建由 runtime 包自己拥有的 typed setting target；
+- 显式声明每一个 source；
+- 使用唯一 source name 和唯一 priority；
+- 让低优先级 base 文件排在高优先级 override 之前；
+- 环境变量 source 使用 `ParserKindNone`；
+- 用 `IsKind` 检查 typed error；
+- 需要运维可追踪性时，记录 `Result.SourceNames`、`Result.Fingerprint` 和 diagnostics。
+
+调用方不应该：
+
+- 依赖未声明的默认 source；
+- 传入 nil context 或 nil target；
+- 不注册 provider 就使用 `ProviderKindRemote`；
+- 把 Koanf 或 mapstructure 暴露成 runtime 自己的公开契约；
+- 假设 `RedactKeys` 会移除敏感值。
+
+## 阅读顺序
+
+实现新的 runtime 集成时，建议按顺序阅读：
+
+1. [契约](contract.md)，理解合法 request 和失败分类。
+2. [管线](pipeline.md)，理解值如何流动以及如何覆盖。
+3. [函数与 API](functions.md)，选择入口函数和扩展点。

--- a/docs/zh-cn/handbook/shared-packages/config/contract.md
+++ b/docs/zh-cn/handbook/shared-packages/config/contract.md
@@ -1,0 +1,156 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/zh-cn/handbook/shared-packages/config/contract.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Config 契约
+
+config 包的契约围绕一个显式 `Request` 展开。调用方提供 runtime 标识、environment 标识、target pointer、source 描述列表和 options。loader 会在读取 source 之前验证这些契约。
+
+## Request 契约
+
+| 字段 | 是否必需 | 语义 |
+| --- | --- | --- |
+| `Runtime` | 是 | 小写 runtime 名称。必须以字母开头，可包含小写字母、数字和连字符。 |
+| `Env` | 是 | 小写环境名称。命名规则和 `Runtime` 相同。 |
+| `Target` | 是 | 指向 struct 或 map 的非 nil pointer。调用方拥有 target 类型和后续校验。 |
+| `Sources` | 通常是 | 要读取的 source 列表。除非 `Options.AllowEmptySources` 为 true，否则空 source 会被拒绝。 |
+| `Options` | 否 | 控制管线行为。空 options 会被规范化为包默认值。 |
+
+这个包只验证 request 形状。它不校验端口、业务开关、租户策略、部署规则等领域 setting 值。
+
+## Source 契约
+
+每个 `Source` 声明一次 provider 读取。
+
+| 字段 | 是否必需 | 语义 |
+| --- | --- | --- |
+| `Name` | 是 | 唯一 source 名称。必须以字母开头，可包含小写字母、数字、连字符、下划线和点。 |
+| `Kind` | 是 | Provider kind。内置 kind 是 `file` 和 `env`；自定义名称可通过验证，但加载前必须注册。 |
+| `Parser` | 是 | Parser kind。内置 kind 是 `yaml`、`json`、`toml` 和 `none`；自定义名称可通过验证，但加载前必须注册。 |
+| `Location` | 是 | Provider 相关位置。文件 source 是文件系统路径；环境变量 source 是必需前缀。 |
+| `Required` | 否 | 必需 source 不可读或缺失会失败。可选缺失 file/env source 会被跳过并留下 diagnostics。 |
+| `Priority` | 否 | 非负 merge 优先级。数字越小越早 merge；后续高优先级 source 覆盖前面的值。priority 必须唯一。 |
+| `Options` | 否 | Provider 级 string options。当前内置 provider 不消费 source options。 |
+
+Provider 与 parser 的兼容性属于 request 契约：
+
+- `ProviderKindEnv` 必须使用 `ParserKindNone`。
+- `ProviderKindFile` 必须使用非 `ParserKindNone` 的 parser。
+- 自定义 provider 和 parser kind 必须通过命名校验，并在 load 前注册到 `LoaderConfig`。
+
+## 内置 Kind
+
+| Kind | 值 | 默认注册 | 说明 |
+| --- | --- | --- | --- |
+| `ProviderKindFile` | `file` | 是 | 读取本地文件为 raw bytes。 |
+| `ProviderKindEnv` | `env` | 是 | 按前缀读取环境变量，并返回 structured dotted keys。 |
+| `ProviderKindRemote` | `remote` | 否 | 为未来或自定义场景命名。默认 loader 不读取 remote source。 |
+| `ParserKindNone` | `none` | 是 | 不做 raw parse，直接返回 provider values。环境变量 source 使用它。 |
+| `ParserKindYAML` | `yaml` | 是 | 解析 YAML object payload。 |
+| `ParserKindJSON` | `json` | 是 | 解析 JSON object payload，并保留 JSON number。 |
+| `ParserKindTOML` | `toml` | 是 | 解析 TOML object payload。 |
+
+## Option 契约
+
+| 字段 | 默认值 | 语义 |
+| --- | --- | --- |
+| `AllowEmptySources` | `false` | 为 true 时允许空 source 列表。 |
+| `MergeStrategy` | `deep_replace` | 当前只支持 `MergeStrategyDeepReplace`。 |
+| `UnknownKeyPolicy` | `reject` | `reject` 遇到未使用 key 会失败；`allow` 会忽略未知 key。 |
+| `Timeout` | `0` | 为正数时，对整个 load 操作应用一个 context timeout。负数非法。 |
+| `RedactKeys` | 空 | 当前实现接受这个字段，但不执行脱敏。 |
+
+不支持的 merge strategy 和 unknown-key policy 会返回 `ErrorKindContract`。
+
+## Result 契约
+
+只有成功 load 并 decode 后才会返回 `Result`。
+
+| 字段 | 语义 |
+| --- | --- |
+| `Runtime` | 从 request 复制。 |
+| `Env` | 从 request 复制。 |
+| `SourceNames` | 按 priority 排序后的 source 名称。被跳过的可选 source 仍会出现。 |
+| `Fingerprint` | Decode 成功后，对 merge 后 value map 计算得到的 `sha256:` fingerprint。 |
+| `Diagnostics` | source 参与情况和 override diagnostics。 |
+
+Fingerprint 代表 merge 后 structured values。它不是 secret-safe digest 契约，因为当前实现不会应用 `RedactKeys`。
+
+## Diagnostics 契约
+
+`Diagnostics.Sources` 记录每个 source 如何参与 merge。
+
+| 字段 | 语义 |
+| --- | --- |
+| `Name` | Source 名称。 |
+| `Kind` | Provider kind。 |
+| `Required` | Source 的 required 标记。 |
+| `Loaded` | provider 加载到数据，或 merge 推断出已有 values 时为 true。 |
+| `Skipped` | 可选缺失 source 被跳过时为 true。 |
+| `Message` | skip 或 provider 状态的人类可读说明。 |
+
+`Diagnostics.Overrides` 记录值替换事件。
+
+| 字段 | 语义 |
+| --- | --- |
+| `Path` | 被替换的 dot path。 |
+| `Source` | 提供替换值的 source。 |
+| `PreviousSource` | 之前提供旧值的 source。 |
+
+嵌套 map 会 deep merge。scalar 和 slice 会被替换。当后续 source 改变之前 source 拥有的路径时，会记录 override diagnostics。
+
+## Error 契约
+
+包内分类错误都使用 `*config.Error`。
+
+| Kind | 含义 |
+| --- | --- |
+| `ErrorKindContract` | 调用方违反 API 或 request 规则。 |
+| `ErrorKindSource` | Provider 无法读取声明的 source。 |
+| `ErrorKindParse` | Parser 无法转换 source payload。 |
+| `ErrorKindMerge` | Parsed source values 无法合并。 |
+| `ErrorKindDecode` | Merged values 无法解码到 target。 |
+
+使用 `IsKind(err, kind)` 或 `errors.Is(err, &config.Error{Kind: kind})` 判断错误类型，不要解析错误字符串。错误字符串用于人类阅读，不应作为机器契约。
+
+## 扩展契约
+
+包通过 `LoaderConfig` 支持自定义管线组件：
+
+- `Providers` 注册额外 `ProviderKind` handler，或覆盖内置 provider。
+- `Parsers` 注册额外 `ParserKind` handler，或覆盖内置 parser。
+- `Merger` 替换默认 deep-replace merger。
+- `Decoder` 替换默认 mapstructure decoder。
+
+自定义组件必须保持调用方期望的公共语义。默认 loader 仍会在调用自定义 provider 和 parser 前验证 request 形状。
+
+## 契约之外
+
+以下行为不属于这个包的契约：
+
+- runtime 级 setting 默认值和校验；
+- 从进程参数、部署清单或服务发现中选择 source list；
+- remote read，除非调用方注册并拥有 provider；
+- hot reload 和 watcher 生命周期；
+- secret 解析；
+- 对返回 values 或 diagnostics 做脱敏；
+- 把 Koanf 或 mapstructure 行为保证成 runtime 公开 API。

--- a/docs/zh-cn/handbook/shared-packages/config/functions.md
+++ b/docs/zh-cn/handbook/shared-packages/config/functions.md
@@ -1,0 +1,175 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/zh-cn/handbook/shared-packages/config/functions.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Config 函数与 API
+
+本页列出包消费者可以依赖的导出 API。它不是 Go documentation 的替代品，而是解释每个导出符号在包契约中的位置。
+
+## Load 入口
+
+| API | 用途 | 使用场景 |
+| --- | --- | --- |
+| `Load(ctx, req)` | 用新的默认 loader 执行一个 request。 | Runtime 只需要内置 file/env provider 和 YAML/JSON/TOML/none parser。 |
+| `NewDefaultLoader()` | 创建包含内置组件的默认 loader。 | Runtime 需要可复用 loader 实例，但不需要自定义组件。 |
+| `NewLoader(LoaderConfig)` | 创建带内置组件和覆盖项的 loader。 | Runtime 需要自定义 provider、parser、merger 或 decoder。 |
+| `(*DefaultLoader).Load(ctx, req)` | 用已配置 loader 执行一个 request。 | Runtime 已拥有 loader 实例。 |
+
+简单本地集成使用 `Load`。需要新增自定义 source kind 时使用 `NewLoader`，例如测试中的 memory provider，或由 runtime 自己拥有的 remote provider。
+
+## Loader 配置
+
+| API | 用途 |
+| --- | --- |
+| `Loader` | 拥有 `Load(ctx, req) (*Result, error)` 的接口。 |
+| `DefaultLoader` | 内置实现，编排 provider、parser、merger、decoder 和 fingerprint。 |
+| `LoaderConfig` | 注册 provider/parser map，以及可选自定义 merger/decoder。 |
+
+`LoaderConfig.Providers` 和 `LoaderConfig.Parsers` 会叠加到内置组件上。如果 map 中包含内置 key，传入组件会替换该 loader 中的内置组件。
+
+## Provider API
+
+| API | 用途 |
+| --- | --- |
+| `Provider` | 拥有 `Read(ctx, source) (*Payload, error)` 的接口。 |
+| `ProviderFunc` | 让函数实现 `Provider` 的 adapter。 |
+| `FileProvider` | 读取本地文件的内置 provider。 |
+| `EnvProvider` | 按环境变量前缀读取的内置 provider。 |
+| `ProviderKindFile` | 内置 `file` provider kind。 |
+| `ProviderKindEnv` | 内置 `env` provider kind。 |
+| `ProviderKindRemote` | 命名为 `remote` 的 kind，默认没有注册 provider。 |
+
+Provider 实现应使用 `SourceError` 表达读取失败，使用 `ContractError` 表达 provider/source 不匹配。Provider 不应该 merge、decode 或校验 runtime 级 setting。
+
+## Parser API
+
+| API | 用途 |
+| --- | --- |
+| `Parser` | 拥有 `Parse(ctx, payload) (map[string]any, error)` 的接口。 |
+| `ParserFunc` | 让函数实现 `Parser` 的 adapter。 |
+| `NoneParser` | 为 structured payload 返回 provider values。 |
+| `YAMLParser` | 解析 YAML object payload。 |
+| `JSONParser` | 解析 JSON object payload。 |
+| `TOMLParser` | 解析 TOML object payload。 |
+| `BuiltinParser(kind)` | 返回内置 parser 和布尔值。 |
+| `ParsePayload(ctx, payload)` | 使用 payload 声明的内置 parser 解析 payload。 |
+
+Parser 实现应使用 `ParseError` 表达 source data 格式错误。当 payload 与 parser 实现不匹配时，应返回 `ContractError`。
+
+## Merge API
+
+| API | 用途 |
+| --- | --- |
+| `Merger` | 拥有 `Merge(ctx, sources, options) (*MergeResult, error)` 的接口。 |
+| `DeepReplaceMerger` | 内置 merger。deep-merge maps，并替换 scalars/slices。 |
+| `MergeParsedSources(ctx, sources, options)` | 使用 `DeepReplaceMerger` 的便捷函数。 |
+| `ParsedSourceFromPayload(payload, values)` | 把 parsed values 与 provider metadata 重新绑定。 |
+
+内置 merger 按 priority 升序排序。它记录 ordered source names、source diagnostics 和 override diagnostics。
+
+## Decode API
+
+| API | 用途 |
+| --- | --- |
+| `Decoder` | 拥有 `Decode(ctx, values, target, options) error` 的接口。 |
+| `MapstructureDecoder` | 基于 mapstructure 的内置 decoder。 |
+| `DecodeValues(ctx, values, target, options)` | 使用 `MapstructureDecoder` 的便捷函数。 |
+| `DecodeMergeResult(ctx, result, target, options)` | 解码 merge result 中的 values。 |
+
+Decode helper 适合测试或自定义管线。Runtime 通常应优先使用完整 loader，因为它会保留 diagnostics 和 fingerprint。
+
+## Validation API
+
+| API | 用途 |
+| --- | --- |
+| `ValidateLoadRequest(ctx, req)` | 加载前验证 request shape。 |
+
+当 runtime 想在构造 loader 前或运行 runtime-specific checks 前 fail fast，可以直接使用 validation。Validation 不保证自定义 provider 或 parser 已注册。
+
+## Error API
+
+| API | 用途 |
+| --- | --- |
+| `Error` | 带有 `Kind`、`Field`、`Reason` 和 wrapped `Err` 的 typed package error。 |
+| `ErrorKindContract` | API 或 request 契约错误。 |
+| `ErrorKindSource` | Source read 失败。 |
+| `ErrorKindParse` | Source parse 失败。 |
+| `ErrorKindMerge` | Merge 失败。 |
+| `ErrorKindDecode` | Decode 失败。 |
+| `ContractError` | 创建 contract error。 |
+| `SourceError` | 创建 source error。 |
+| `ParseError` | 创建 parse error。 |
+| `MergeError` | 创建 merge error。 |
+| `DecodeError` | 创建 decode error。 |
+| `IsKind(err, kind)` | 判断 error 中是否包含指定 kind 的 config error。 |
+
+调用方应该基于 error kind 分支，而不是解析字符串。
+
+## 数据类型
+
+| Type | 用途 |
+| --- | --- |
+| `Request` | 一次 load 操作。 |
+| `Options` | Load、merge、decode 和 diagnostics 行为。 |
+| `Source` | 一个 provider source 描述。 |
+| `Payload` | Parser 转换前的 provider 输出。 |
+| `ParsedSource` | 带 source metadata 的 parsed source values。 |
+| `MergeResult` | Merged values、source names 和 diagnostics。 |
+| `Result` | Decode 和 fingerprint 成功后的 load 输出。 |
+| `Diagnostics` | Source diagnostics 和 override diagnostics。 |
+| `SourceDiagnostic` | 一个 source 参与记录。 |
+| `MergeOverride` | 一个 override 记录。 |
+
+这些类型都是普通 Go struct。包不会把 source shape 隐藏在全局状态后面。
+
+## 常见用法
+
+### 默认本地加载
+
+使用 `Load(ctx, req)` 搭配 file 和 env sources。这是本地 runtime 启动的常规路径。
+
+### 测试用 memory source
+
+使用 `NewLoader(LoaderConfig{Providers: ..., Parsers: ...})` 搭配自定义 kind 和 `ProviderFunc` / `ParserFunc`。这样测试不需要依赖文件系统或进程环境状态。
+
+### Merge 前检查
+
+只有在构建自定义 runtime 管线时，才需要直接使用 providers、parsers 和 `MergeParsedSources`。大多数消费者不需要这样做。
+
+### Decode-only 测试
+
+测试 target struct tags、duration conversion 或 unknown-key 行为时，可以使用 `DecodeValues` 或 `DecodeMergeResult`，不需要读取 source。
+
+## 调用方责任
+
+每个消费者必须自己负责：
+
+- setting target type 定义；
+- runtime-specific defaults；
+- decode 后的领域校验；
+- source list 选择；
+- 环境变量 prefix 策略；
+- secret 和 redaction 策略；
+- 启动日志策略；
+- hot reload、remote configuration 或 watcher 生命周期。
+
+共享包提供的是确定性的配置加载原语。它不替代 runtime 配置设计。

--- a/docs/zh-cn/handbook/shared-packages/config/pipeline.md
+++ b/docs/zh-cn/handbook/shared-packages/config/pipeline.md
@@ -1,0 +1,181 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/zh-cn/handbook/shared-packages/config/pipeline.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Config 管线
+
+默认 loader 会把一个 request 送入固定的本地管线：
+
+```text
+Request
+  -> validate request and normalize options
+  -> apply request timeout when configured
+  -> provider read for each source
+  -> parser parse for each payload
+  -> merge parsed sources by priority
+  -> decode merged values into target
+  -> fingerprint merged values
+  -> return Result
+```
+
+每个阶段都会接收 request context。如果 `Options.Timeout` 为正数，loader 会在 provider read 开始前用该 timeout 包装 context。
+
+## 阶段 1：Validation
+
+`ValidateLoadRequest` 在读取 source 前执行。它检查：
+
+- context 非 nil；
+- `Runtime` 和 `Env` 合法；
+- target 是指向 struct 或 map 的非 nil pointer；
+- option 值受支持；
+- 除非 `AllowEmptySources` 为 true，否则 source 必须存在；
+- source name 唯一；
+- source priority 唯一；
+- source name、provider kind、parser kind、location 和 priority 合法；
+- 内置 file/env provider 与 parser 的兼容性。
+
+Validation 允许符合命名规则的自定义 provider 和 parser kind。若 load 时没有注册对应组件，后续仍会以 `ErrorKindContract` 失败。
+
+## 阶段 2：Provider Read
+
+Provider 返回 `Payload`。Payload 可以包含 `Raw` bytes、structured `Values`、provider `Metadata` 和 `SourceDiagnostic`。
+
+### File Provider
+
+`FileProvider` 从本地文件系统读取 `Source.Location`。
+
+- 必需文件缺失返回 `ErrorKindSource`。
+- 可选文件缺失返回 skipped payload。
+- location 指向目录会返回 `ErrorKindSource`。
+- 成功读取时填充 `Raw`、文件路径 metadata 和 loaded diagnostic。
+
+File provider 不解析 bytes，只负责读取 source。
+
+### Environment Provider
+
+`EnvProvider` 优先从 `Lookup` 读取环境变量条目；未提供时读取 `os.Environ`。
+
+它使用 `Source.Location` 作为前缀过滤条目。匹配的 key 会这样规范化：
+
+- 移除 source prefix；
+- 裁剪首尾下划线；
+- 转小写；
+- 把双下划线替换成点；
+- 把剩余下划线替换成点。
+
+示例：
+
+| 环境变量 key | Prefix | 规范化 key |
+| --- | --- | --- |
+| `DOX_SERVER_APP_NAME` | `DOX_SERVER_` | `app.name` |
+| `DOX_SERVER_HTTP__ADDRESS` | `DOX_SERVER_` | `http.address` |
+
+没有匹配变量时，required env source 返回 `ErrorKindSource`；optional env source 被跳过并留下 diagnostics。
+
+## 阶段 3：Parser
+
+Parser 把一个 provider payload 转换成 `map[string]any`。
+
+| Parser | 输入 | 行为 |
+| --- | --- | --- |
+| `NoneParser` | `Payload.Values` | 返回 shallow copy。用于 env source。 |
+| `YAMLParser` | `Payload.Raw` | 解析 YAML，并要求 root 是 object。 |
+| `JSONParser` | `Payload.Raw` | 解析 JSON，拒绝 trailing data，保留 number 为 `json.Number`，并要求 root 是 object。 |
+| `TOMLParser` | `Payload.Raw` | 解析 TOML，并要求 root 是 object。 |
+
+被跳过的 optional payload 会解析为空 map。格式错误返回 `ErrorKindParse`。Parser 实现与 payload kind 不匹配返回 `ErrorKindContract`。
+
+## 阶段 4：Merge
+
+`DeepReplaceMerger` 按 `Source.Priority` 升序排列 parsed sources。优先级数字越小越早 merge。后续高优先级 source 覆盖之前的值。
+
+Merge 行为：
+
+- 嵌套 map deep merge；
+- scalar 替换之前的 scalar；
+- slice 替换之前的 slice；
+- skipped source 会出现在 `SourceNames` 和 source diagnostics 中，但不会改变 values；
+- 重复 source name 或 priority 返回 `ErrorKindContract`；
+- 使用 `ParserKindNone` 的 env source 会在 merge 前把 dotted keys 展开成嵌套 map。
+
+示例：
+
+```text
+base priority 10:
+  app.name = dox
+  http.timeout = 5s
+
+env priority 100:
+  app.name = dox-env
+  http.timeout = 10s
+
+merged:
+  app.name = dox-env
+  http.timeout = 10s
+```
+
+结果会为 `app.name` 和 `http.timeout` 记录 override diagnostics，表示 `env` 替换了 `base`。
+
+冲突的环境变量 dotted keys 会返回 `ErrorKindMerge`。例如同一个 env source 不能同时提供 `app=dox` 和 `app.name=dox`，因为同一路径不能既是 scalar 又是 map。
+
+## 阶段 5：Decode
+
+`MapstructureDecoder` 把 merged values 解码到调用方 target。
+
+Decode 行为：
+
+- target 必须是指向 struct 或 map 的非 nil pointer；
+- struct tag 使用 `mapstructure`；
+- 启用 weak type conversion；
+- 启用 string 到 `time.Duration` 的转换；
+- decode 前会 zero target fields；
+- 默认拒绝未知 key；
+- `UnknownKeyPolicyAllow` 允许未知 key。
+
+Decode 失败返回 `ErrorKindDecode`。target 非法返回 `ErrorKindContract`。
+
+## 阶段 6：Fingerprint 和 Result
+
+Decode 成功后，loader 会根据 merged structured value map 计算稳定的 `sha256:` fingerprint。Result 包含：
+
+- request runtime；
+- request environment；
+- 排序后的 source names；
+- fingerprint；
+- source diagnostics；
+- merge override diagnostics。
+
+Fingerprint 代表 merged values，而不是 decoded target。如果 decode 失败，不会返回 result。
+
+## 运维备注
+
+Source name 应体现用途，例如 `base`、`local`、`secrets` 或 `env`。Priority 建议留出间隔，例如 `10`、`20`、`100`，方便之后插入新的 override 层。
+
+为了保持确定性：
+
+- 避免重复 priority；
+- 文件格式保持 object root；
+- 环境变量 prefix 按 runtime 隔离；
+- 启动成功后记录 source names 和 fingerprint；
+- 排查覆盖行为时记录 diagnostics。
+
+不要记录 raw merged values，除非调用方已经应用自己的脱敏策略。


### PR DESCRIPTION
## Description

Adds a bilingual engineering handbook for the shared config package. The docs establish `packages/shared/config` as a standalone shared-package reference that future Web, Scheduling, Collection, and Computation engineering manuals can link to instead of duplicating package behavior.

This PR intentionally changes documentation only. It describes the current loader contract, local pipeline, extension points, and explicit non-capabilities such as remote provider reads, hot reload, runtime setting validation, and `RedactKeys` enforcement.

## Related Links

- Closes #38

## Scope

- [ ] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [x] Security
- [x] Backend

## Implementation Notes

- Adds English handbook pages under `docs/en-us/handbook/shared-packages/config/`.
- Adds Chinese handbook pages under `docs/zh-cn/handbook/shared-packages/config/`.
- Documents package overview, request/source/options/result/error contracts, the provider/parser/merge/decode/fingerprint pipeline, and exported API usage.
- Calls out implemented behavior separately from non-capabilities, including the currently unenforced `Options.RedactKeys` field.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands run:

```sh
git diff --cached --check
git diff --check
git diff origin/develop...HEAD --check
```

Not run:

```sh
go test ./packages/shared/config
```

The current environment does not have a `go` binary on `PATH`, so Go package tests could not be executed locally for this docs-only PR.

## Risks

The handbook is now the first shared-package docs structure under `docs/{language}/handbook/`. Future setting and logging handbook PRs should follow the same directory shape and update cross-package indexes only when those indexes are introduced.
