### PR TITLE
gh-39 [docs]: Add shared setting package handbook

### DIFF
--- a/docs/en-us/handbook/shared-packages/setting/README.md
+++ b/docs/en-us/handbook/shared-packages/setting/README.md
@@ -1,0 +1,134 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/en-us/handbook/shared-packages/setting/README.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Setting Package Handbook
+
+| Previous | Up | Next |
+| --- | --- | --- |
+| [Shared config package](../config/README.md) | Shared packages | [Chapter 1: Contract](contract.md) |
+
+> [!NOTE]
+> This handbook is written as a short module book. Read it in order when adding a new runtime setting aggregate, and use the chapter links when returning for a specific contract or API detail.
+
+`packages/shared/setting` defines reusable Dox identity and deployment setting fragments. It is intentionally smaller than a runtime setting system: it provides shared fragments, defaults, enum constraints, and validation helpers that each runtime can compose into its own concrete aggregate.
+
+## Reading Path
+
+```mermaid
+flowchart LR
+    A["Start: Overview"] --> B["Chapter 1: Contract"]
+    B --> C["Chapter 2: Model"]
+    C --> D["Chapter 3: Functions and API"]
+```
+
+1. [Chapter 1: Contract](contract.md) defines what the package owns, what it refuses to own, and how validation errors should be interpreted.
+2. [Chapter 2: Model](model.md) describes each shared fragment, its fields, defaults, and validation tags.
+3. [Chapter 3: Functions and API](functions.md) lists exported types, methods, constants, and caller obligations.
+
+## Book Scope
+
+This handbook is the package-level reference for:
+
+- Dox runtime identity values;
+- Dox deployment environment values;
+- shared identity fragments such as `Organization`, `Application`, `System`, and `Service`;
+- shared deployment fragments such as `Deployment`;
+- Dox-owned validation tags and validation error shape;
+- the reuse boundary between shared fragments and runtime-owned setting aggregates.
+
+It is meant to be linked from the future Web, Scheduling, Collection, and Computation engineering manuals.
+
+## Package Position
+
+`packages/shared/setting` sits between generic config loading and runtime-specific setting aggregates.
+
+```mermaid
+flowchart TD
+    config["packages/shared/config<br/>load, merge, decode"] --> runtime["runtime setting aggregate<br/>server, scheduler, collector, compute"]
+    setting["packages/shared/setting<br/>identity and deployment fragments"] --> runtime
+    logging["packages/shared/logging<br/>logging configuration model"] --> runtime
+    runtime --> bootstrap["runtime bootstrap<br/>validation, startup policy, subsystem wiring"]
+```
+
+The shared setting package is consumed by runtime packages, but it does not know which concrete runtime is being built. For example, `server/internal/setting` composes these fragments and then adds server-owned rules such as forcing `System.Runtime` to `server`.
+
+## Current Capability
+
+The package currently provides:
+
+- `Runtime` enum values for `server`, `scheduler`, `collector`, and `compute`;
+- `Env` enum values for `dev`, `test`, `staging`, and `prod`;
+- default organization and application names;
+- `Organization`, `Application`, `System`, `Service`, and `Deployment` fragments;
+- conservative `Default` methods for fragments;
+- Dox-owned validation rules for kebab names, stable identifiers, runtime values, and env values;
+- `ValidationError` and `FieldError` types that hide the third-party validator error type from callers.
+
+## Current Non-capability
+
+The package currently does not provide:
+
+- a root `Setting` aggregate;
+- HTTP, database, security, queue, logging, or plugin setting groups;
+- config file loading, source merging, or decoding;
+- service discovery or deployment manifest modeling;
+- default runtime selection for all systems;
+- server-only validation rules;
+- runtime bootstrap behavior.
+
+> [!IMPORTANT]
+> Do not move runtime-owned policy into this package because one runtime currently needs it. Shared fragments should stay reusable across Web, Scheduling, Collection, and Computation.
+
+## Consumer Integration Checklist
+
+- [ ] Compose only the fragments whose semantics match the runtime aggregate.
+- [ ] Fill shared defaults before runtime-specific defaults when doing so keeps the flow easy to reason about.
+- [ ] Keep runtime-owned identity rules in the runtime package.
+- [ ] Validate shared fragments with their `Validate` methods or `setting.Validate`.
+- [ ] Join shared validation errors with runtime-owned validation errors at the aggregate boundary.
+- [ ] Document any runtime-specific default or stricter validation rule outside this shared package handbook.
+
+<details>
+<summary>Example: current server composition</summary>
+
+`server/internal/setting.Identity` composes these shared fragments:
+
+```go
+type Identity struct {
+	Organization sharedsetting.Organization `json:"organization" yaml:"organization" mapstructure:"organization"`
+	Application  sharedsetting.Application  `json:"application" yaml:"application" mapstructure:"application"`
+	System       sharedsetting.System       `json:"system" yaml:"system" mapstructure:"system"`
+	Service      sharedsetting.Service      `json:"service" yaml:"service" mapstructure:"service"`
+	Deployment   sharedsetting.Deployment   `json:"deployment" yaml:"deployment" mapstructure:"deployment"`
+}
+```
+
+The server package then owns the server-specific rule that `System.Runtime` must be `server`. That rule is not part of the shared package contract.
+
+</details>
+
+## Navigation
+
+| Previous | Up | Next |
+| --- | --- | --- |
+| [Shared config package](../config/README.md) | Shared packages | [Chapter 1: Contract](contract.md) |

--- a/docs/en-us/handbook/shared-packages/setting/contract.md
+++ b/docs/en-us/handbook/shared-packages/setting/contract.md
@@ -1,0 +1,152 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/en-us/handbook/shared-packages/setting/contract.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Chapter 1: Shared Setting Contract
+
+| Previous | Up | Next |
+| --- | --- | --- |
+| [Overview](README.md) | [Shared setting package](README.md) | [Chapter 2: Model](model.md) |
+
+> [!TIP]
+> Read this chapter before composing the package into a runtime aggregate. It defines which decisions belong in the shared package and which decisions must stay in runtime-owned code.
+
+## Contract Summary
+
+`packages/shared/setting` owns reusable identity and deployment fragments. It does not own a concrete runtime setting aggregate.
+
+| Contract Area | Package Responsibility | Caller Responsibility |
+| --- | --- | --- |
+| Runtime values | Declare supported Dox runtime enum values. | Decide which runtime value a concrete aggregate accepts. |
+| Environment values | Declare supported Dox deployment env values. | Decide how env is seeded from bootstrap or deployment inputs. |
+| Fragment defaults | Fill conservative shared defaults. | Add runtime-specific defaults after or around shared defaults. |
+| Fragment validation | Validate shared field syntax and enum values. | Validate runtime-specific combinations and stricter rules. |
+| Error shape | Return Dox-owned validation error types. | Join or translate errors at runtime aggregate boundaries. |
+
+## Identity Contract
+
+The package defines identity fragments, not a global identity aggregate. A runtime may compose these fragments into its own group when their semantics match:
+
+- `Organization` for ownership and governance identity;
+- `Application` for the Dox application family;
+- `System` for the Dox runtime identity;
+- `Service` for one logical service identity;
+- `Deployment` for environment and deployment location.
+
+The shared package does not decide that a server must use `RuntimeServer`, that a scheduler must use `RuntimeScheduler`, or that a deployment env came from a specific flag. Runtime packages own those decisions.
+
+## Default Contract
+
+Defaults are intentionally conservative.
+
+| Fragment | Shared Default Behavior |
+| --- | --- |
+| `Organization` | Empty `Name` becomes `opendox`. |
+| `Application` | Empty `Name` becomes `dox`. |
+| `System` | No runtime is invented. Runtime identity must be explicit or set by a consumer package. |
+| `Service` | Empty `Namespace` becomes `Application.Name`; empty `Name` becomes `string(System.Runtime)` only when runtime is already known. |
+| `Deployment` | Empty `Env` becomes `dev`. |
+
+> [!IMPORTANT]
+> `System.Default` is a no-op by design. A shared package cannot safely choose between `server`, `scheduler`, `collector`, and `compute`.
+
+## Validation Contract
+
+Validation uses Dox-owned tags registered on top of `go-playground/validator`.
+
+| Tag | Meaning | Current Rule |
+| --- | --- | --- |
+| `dox_kebab` | Stable kebab-case name. | Must start with a lowercase letter and may contain lowercase letters, digits, and single hyphen-separated segments. |
+| `dox_identifier` | Stable infrastructure or governance identifier. | Must start and end with a lowercase letter or digit; internal characters may include lowercase letters, digits, dots, underscores, and hyphens. |
+| `dox_runtime` | Supported Dox runtime. | Must be one of `server`, `scheduler`, `collector`, or `compute`. |
+| `dox_env` | Supported Dox deployment environment. | Must be one of `dev`, `test`, `staging`, or `prod`. |
+
+The validator exposes field names through `mapstructure` tags first, then `json` tags, then Go field names.
+
+## Error Contract
+
+The package exposes:
+
+- `FieldError`, with `Field` and `Rule`;
+- `ValidationError`, with `Fields []FieldError`;
+- `Validate(value any) error`, which returns nil or a `ValidationError`.
+
+Callers should treat `ValidationError.Fields` as the machine-readable contract. The error string is compact and useful for logs, but callers should not parse it when field-level handling is needed.
+
+<details>
+<summary>Example: validation field shape</summary>
+
+An invalid system runtime produces a field entry similar to:
+
+```text
+Field: System.runtime
+Rule: dox_runtime
+```
+
+The `runtime` field name comes from the `mapstructure:"runtime"` tag.
+
+</details>
+
+## Runtime Boundary
+
+Runtime packages compose shared fragments and then add runtime policy.
+
+```mermaid
+sequenceDiagram
+    participant Shared as packages/shared/setting
+    participant Runtime as runtime/internal/setting
+    participant Bootstrap as runtime bootstrap
+
+    Runtime->>Shared: call fragment Default methods
+    Runtime->>Runtime: apply runtime-specific defaults
+    Runtime->>Shared: call fragment Validate methods
+    Runtime->>Runtime: validate runtime-owned combinations
+    Bootstrap->>Runtime: consume concrete aggregate
+```
+
+Current server behavior is a consumer example:
+
+- server composes the shared identity fragments;
+- server defaults missing `System.Runtime` to `server`;
+- server rejects a valid non-server runtime value;
+- server may seed `Deployment.Env` from bootstrap options.
+
+Those rules are documented as server behavior, not as shared package behavior.
+
+## Out of Contract
+
+The following are outside the shared setting contract:
+
+- root runtime `Setting` structs;
+- config source loading or decoding;
+- logging configuration;
+- HTTP, database, queue, plugin, or security setting groups;
+- service registry or deployment manifest schemas;
+- runtime bootstrap, lifecycle, or subsystem wiring;
+- choosing a runtime identity for all consumers;
+- creating process-wide defaults from environment variables.
+
+## Navigation
+
+| Previous | Up | Next |
+| --- | --- | --- |
+| [Overview](README.md) | [Shared setting package](README.md) | [Chapter 2: Model](model.md) |

--- a/docs/en-us/handbook/shared-packages/setting/functions.md
+++ b/docs/en-us/handbook/shared-packages/setting/functions.md
@@ -1,0 +1,182 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/en-us/handbook/shared-packages/setting/functions.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Chapter 3: Shared Setting Functions and API
+
+| Previous | Up | Next |
+| --- | --- | --- |
+| [Chapter 2: Model](model.md) | [Shared setting package](README.md) | End |
+
+> [!NOTE]
+> This chapter is the API reference for the package. If a behavior depends on model meaning, the related model section is linked inline.
+
+## Constants
+
+| API | Value | Purpose |
+| --- | --- | --- |
+| `DefaultOrganizationName` | `opendox` | Default organization identity. |
+| `DefaultApplicationName` | `dox` | Default product or application family identity. |
+
+## Runtime API
+
+| API | Purpose |
+| --- | --- |
+| `type Runtime string` | Dox runtime identity value. |
+| `RuntimeServer` | Web backend runtime. |
+| `RuntimeScheduler` | Scheduling runtime. |
+| `RuntimeCollector` | Collection runtime. |
+| `RuntimeCompute` | Computation runtime. |
+| `(Runtime).IsValid() bool` | Returns true for supported runtime values. |
+
+Runtime validation is shared, but runtime selection is not. For example, the server package may require `RuntimeServer`, while a scheduler package should require `RuntimeScheduler`.
+
+## Env API
+
+| API | Purpose |
+| --- | --- |
+| `type Env string` | Deployment environment value. |
+| `EnvDev` | Development environment. |
+| `EnvTest` | Test environment. |
+| `EnvStaging` | Staging environment. |
+| `EnvProd` | Production environment. |
+| `(Env).IsValid() bool` | Returns true for supported environment values. |
+
+## Fragment API
+
+| Fragment | Default Method | Validate Method |
+| --- | --- | --- |
+| `Organization` | `(*Organization).Default() error` | `(Organization).Validate() error` |
+| `Application` | `(*Application).Default() error` | `(Application).Validate() error` |
+| `System` | `(*System).Default() error` | `(System).Validate() error` |
+| `Service` | `(*Service).Default(application, system) error` | `(Service).Validate() error` |
+| `Deployment` | `(*Deployment).Default() error` | `(Deployment).Validate() error` |
+
+Default methods return an error when called on a nil receiver. Validate methods call the package-level `Validate` helper.
+
+## Default Method Behavior
+
+| Method | Behavior |
+| --- | --- |
+| `Organization.Default` | Sets empty `Name` to `DefaultOrganizationName`. |
+| `Application.Default` | Sets empty `Name` to `DefaultApplicationName`. |
+| `System.Default` | Checks receiver only. It does not set `Runtime`. |
+| `Service.Default` | Sets empty `Namespace` from `application.Name`; sets empty `Name` from `system.Runtime` when runtime is known. |
+| `Deployment.Default` | Sets empty `Env` to `EnvDev`. |
+
+<details>
+<summary>Example: default order in a runtime aggregate</summary>
+
+```go
+func (i *Identity) Default() error {
+	if err := i.Organization.Default(); err != nil {
+		return err
+	}
+	if err := i.Application.Default(); err != nil {
+		return err
+	}
+	if err := i.System.Default(); err != nil {
+		return err
+	}
+	if i.System.Runtime == "" {
+		i.System.Runtime = sharedsetting.RuntimeServer
+	}
+	if err := i.Service.Default(i.Application, i.System); err != nil {
+		return err
+	}
+	return i.Deployment.Default()
+}
+```
+
+The runtime package owns the line that sets `RuntimeServer`.
+
+</details>
+
+## Validation API
+
+| API | Purpose |
+| --- | --- |
+| `Validate(value any) error` | Validates a struct with registered Dox validation tags. |
+| `FieldError` | Machine-readable field failure with `Field` and `Rule`. |
+| `ValidationError` | List of field failures. |
+| `(*ValidationError).Error() string` | Compact log-friendly error message. |
+
+The validation engine is initialized once and registers:
+
+- `dox_kebab`;
+- `dox_identifier`;
+- `dox_runtime`;
+- `dox_env`.
+
+Field names are derived from `mapstructure` tags first. That keeps validation output aligned with decoded configuration keys.
+
+## Caller Recipes
+
+### Compose a runtime identity group
+
+Define a runtime-owned group that embeds or contains shared fragments. Do not expose `packages/shared/setting` as the entire runtime setting aggregate.
+
+### Add runtime-specific validation
+
+Join shared validation with runtime-specific validation:
+
+```go
+func (i Identity) Validate() error {
+	return errors.Join(
+		i.Organization.Validate(),
+		i.Application.Validate(),
+		i.System.Validate(),
+		i.validateServerRuntime(),
+		i.Service.Validate(),
+		i.Deployment.Validate(),
+	)
+}
+```
+
+### Keep runtime bootstrap separate
+
+Bootstrap may provide seed values such as env, instance ID, or region. The shared package should not read flags, environment variables, files, or process metadata directly.
+
+## Caller Obligations
+
+Every runtime consumer must own:
+
+- the root `Setting` aggregate;
+- group composition;
+- runtime identity selection;
+- runtime-specific defaults;
+- validation that depends on combinations across fragments;
+- bootstrap-derived seed values;
+- documentation for stricter runtime behavior.
+
+## API Stability Notes
+
+- Shared fragments are intended to be reused across Dox runtimes.
+- Validation tags are part of the public package behavior.
+- The third-party validator implementation is not exposed as the caller-facing error type.
+- Adding a new runtime or environment value changes shared validation semantics and should be treated as a contract change.
+
+## Navigation
+
+| Previous | Up | Next |
+| --- | --- | --- |
+| [Chapter 2: Model](model.md) | [Shared setting package](README.md) | End |

--- a/docs/en-us/handbook/shared-packages/setting/model.md
+++ b/docs/en-us/handbook/shared-packages/setting/model.md
@@ -1,0 +1,185 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/en-us/handbook/shared-packages/setting/model.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Chapter 2: Shared Setting Model
+
+| Previous | Up | Next |
+| --- | --- | --- |
+| [Chapter 1: Contract](contract.md) | [Shared setting package](README.md) | [Chapter 3: Functions and API](functions.md) |
+
+> [!NOTE]
+> This chapter describes data shape. For method behavior and exported helpers, continue to [Chapter 3](functions.md).
+
+## Model Map
+
+```mermaid
+classDiagram
+    class Organization {
+        string Name
+        string Owner
+        string CostCenter
+        string Project
+    }
+    class Application {
+        string Name
+    }
+    class System {
+        Runtime Runtime
+    }
+    class Service {
+        string Namespace
+        string Name
+        string InstanceID
+    }
+    class Deployment {
+        Env Env
+        string Region
+        string Zone
+        string Cluster
+        string K8sNamespace
+    }
+    Application --> Service : default namespace
+    System --> Service : default name
+```
+
+The package exports independent fragments. It does not export a root aggregate tying them together.
+
+## Runtime
+
+`Runtime` identifies one Dox runtime system.
+
+| Constant | Value | Meaning |
+| --- | --- | --- |
+| `RuntimeServer` | `server` | Web backend runtime. |
+| `RuntimeScheduler` | `scheduler` | Scheduling runtime. |
+| `RuntimeCollector` | `collector` | Collection runtime. |
+| `RuntimeCompute` | `compute` | Computation runtime. |
+
+Use `Runtime.IsValid()` to check whether a value is one of the supported Dox runtime names.
+
+## Env
+
+`Env` identifies a deployment environment.
+
+| Constant | Value | Meaning |
+| --- | --- | --- |
+| `EnvDev` | `dev` | Development environment. |
+| `EnvTest` | `test` | Test environment. |
+| `EnvStaging` | `staging` | Staging environment. |
+| `EnvProd` | `prod` | Production environment. |
+
+Use `Env.IsValid()` to check whether a value is one of the supported Dox environment names.
+
+## Organization
+
+`Organization` describes shared ownership and governance identity.
+
+| Field | Tags | Default | Validation | Intent |
+| --- | --- | --- | --- | --- |
+| `Name` | `json/yaml/mapstructure:"name"` | `opendox` when empty | `required,dox_identifier` | Organization identity. |
+| `Owner` | `owner` | Empty | `omitempty,dox_identifier` | Owning team or owner code. |
+| `CostCenter` | `cost_center` | Empty | `omitempty,dox_identifier` | Cost allocation code. |
+| `Project` | `project` | Empty | `omitempty,dox_identifier` | Project identity. |
+
+Keep these values stable and machine-friendly. Human display names belong in runtime or product metadata, not this fragment.
+
+## Application
+
+`Application` describes the product or application family identity.
+
+| Field | Tags | Default | Validation | Intent |
+| --- | --- | --- | --- | --- |
+| `Name` | `json/yaml/mapstructure:"name"` | `dox` when empty | `required,dox_kebab` | Dox application family name. |
+
+This value can seed `Service.Namespace` through `Service.Default`.
+
+## System
+
+`System` describes the Dox core system identity for a runtime.
+
+| Field | Tags | Default | Validation | Intent |
+| --- | --- | --- | --- | --- |
+| `Runtime` | `json/yaml/mapstructure:"runtime"` | None | `required,dox_runtime` | Runtime system identity. |
+
+`System.Default` intentionally does not set `Runtime`. Concrete runtime packages should set it when they own enough context.
+
+## Service
+
+`Service` describes one logical service identity.
+
+| Field | Tags | Default | Validation | Intent |
+| --- | --- | --- | --- | --- |
+| `Namespace` | `json/yaml/mapstructure:"namespace"` | `Application.Name` when empty | `required,dox_kebab` | Service namespace. |
+| `Name` | `json/yaml/mapstructure:"name"` | `string(System.Runtime)` when empty and runtime is known | `required,dox_kebab` | Logical service name. |
+| `InstanceID` | `json/yaml/mapstructure:"instance_id"` | Empty | `omitempty,dox_identifier` | Specific process, pod, node, or deployment instance. |
+
+Services may share `InstanceID` values when the caller intentionally models multiple logical services running in one process or pod.
+
+## Deployment
+
+`Deployment` describes where a runtime or service is deployed.
+
+| Field | Tags | Default | Validation | Intent |
+| --- | --- | --- | --- | --- |
+| `Env` | `json/yaml/mapstructure:"env"` | `dev` when empty | `required,dox_env` | Deployment environment. |
+| `Region` | `region` | Empty | `omitempty,dox_identifier` | Cloud or operational region. |
+| `Zone` | `zone` | Empty | `omitempty,dox_identifier` | Availability zone or equivalent placement. |
+| `Cluster` | `cluster` | Empty | `omitempty,dox_identifier` | Cluster identity. |
+| `K8sNamespace` | `k8s_namespace` | Empty | `omitempty,dox_identifier` | Kubernetes namespace. |
+
+`Deployment.Default` is intentionally limited to `EnvDev`. It does not invent region, zone, cluster, or namespace values.
+
+## Validation Rule Details
+
+| Rule | Accepts | Rejects |
+| --- | --- | --- |
+| `dox_kebab` | `dox`, `dox-server`, `iam-service` | `Dox`, `dox_iam`, `iam-service-` |
+| `dox_identifier` | `opendox`, `us-east-1`, `server_pod.1` | `Platform Team`, `dox-prod-`, `_hidden` |
+| `dox_runtime` | `server`, `scheduler`, `collector`, `compute` | `worker`, `queue`, `api` |
+| `dox_env` | `dev`, `test`, `staging`, `prod` | `stage`, `production`, `local` |
+
+> [!WARNING]
+> The validation rules prefer stable identifiers over human-readable labels. Put display labels in another model if a user-facing name is required.
+
+## Current Consumer Relationship
+
+The current server setting package composes shared fragments like this:
+
+```mermaid
+flowchart TD
+    org["setting.Organization"] --> identity["server/internal/setting.Identity"]
+    app["setting.Application"] --> identity
+    system["setting.System"] --> identity
+    service["setting.Service"] --> identity
+    deployment["setting.Deployment"] --> identity
+    identity --> root["server/internal/setting.Setting"]
+    logging["packages/shared/logging.Config"] --> root
+```
+
+This diagram is a consumer example. The shared package still exports only independent fragments.
+
+## Navigation
+
+| Previous | Up | Next |
+| --- | --- | --- |
+| [Chapter 1: Contract](contract.md) | [Shared setting package](README.md) | [Chapter 3: Functions and API](functions.md) |

--- a/docs/zh-cn/handbook/shared-packages/setting/README.md
+++ b/docs/zh-cn/handbook/shared-packages/setting/README.md
@@ -1,0 +1,134 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/zh-cn/handbook/shared-packages/setting/README.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Setting 包手册
+
+| 上一章 | 上级 | 下一章 |
+| --- | --- | --- |
+| [Shared config 包](../config/README.md) | Shared packages | [第 1 章：契约](contract.md) |
+
+> [!NOTE]
+> 这份手册按一个短模块书来写。新增 runtime setting aggregate 时请按顺序阅读；回查具体契约或 API 时使用章节链接。
+
+`packages/shared/setting` 定义可复用的 Dox identity 和 deployment setting fragments。它刻意小于一个 runtime setting system：它只提供共享 fragment、默认值、enum 约束和 validation helpers，各 runtime 再把这些 fragment 组合进自己的 concrete aggregate。
+
+## 阅读路径
+
+```mermaid
+flowchart LR
+    A["起点：总览"] --> B["第 1 章：契约"]
+    B --> C["第 2 章：模型"]
+    C --> D["第 3 章：函数与 API"]
+```
+
+1. [第 1 章：契约](contract.md) 定义包负责什么、不负责什么，以及如何理解 validation errors。
+2. [第 2 章：模型](model.md) 描述每个 shared fragment、字段、默认值和 validation tags。
+3. [第 3 章：函数与 API](functions.md) 列出导出类型、方法、常量和调用方责任。
+
+## 本书范围
+
+这份手册是以下内容的包级参考：
+
+- Dox runtime identity values；
+- Dox deployment environment values；
+- `Organization`、`Application`、`System`、`Service` 等 shared identity fragments；
+- `Deployment` 等 shared deployment fragments；
+- Dox-owned validation tags 和 validation error shape；
+- shared fragments 与 runtime-owned setting aggregates 的复用边界。
+
+未来 Web、Scheduling、Collection、Computation 的工程手册都可以链接这里。
+
+## 包定位
+
+`packages/shared/setting` 位于通用 config loading 和 runtime-specific setting aggregates 之间。
+
+```mermaid
+flowchart TD
+    config["packages/shared/config<br/>load, merge, decode"] --> runtime["runtime setting aggregate<br/>server, scheduler, collector, compute"]
+    setting["packages/shared/setting<br/>identity and deployment fragments"] --> runtime
+    logging["packages/shared/logging<br/>logging configuration model"] --> runtime
+    runtime --> bootstrap["runtime bootstrap<br/>validation, startup policy, subsystem wiring"]
+```
+
+Shared setting package 被 runtime packages 消费，但它不知道正在构建哪个 concrete runtime。例如 `server/internal/setting` 会组合这些 fragments，并额外添加 server-owned 规则，例如强制 `System.Runtime` 为 `server`。
+
+## 当前能力
+
+这个包当前提供：
+
+- `server`、`scheduler`、`collector`、`compute` 的 `Runtime` enum values；
+- `dev`、`test`、`staging`、`prod` 的 `Env` enum values；
+- 默认 organization 和 application 名称；
+- `Organization`、`Application`、`System`、`Service`、`Deployment` fragments；
+- 保守的 fragment `Default` methods；
+- Dox-owned validation rules，用于 kebab names、stable identifiers、runtime values 和 env values；
+- `ValidationError` 和 `FieldError` 类型，避免调用方依赖第三方 validator error 类型。
+
+## 当前非能力
+
+这个包当前不提供：
+
+- root `Setting` aggregate；
+- HTTP、database、security、queue、logging 或 plugin setting groups；
+- config file loading、source merging 或 decoding；
+- service discovery 或 deployment manifest modeling；
+- 所有系统的默认 runtime selection；
+- server-only validation rules；
+- runtime bootstrap behavior。
+
+> [!IMPORTANT]
+> 不要因为某个 runtime 当前需要某条策略，就把 runtime-owned policy 移到这个包里。Shared fragments 必须继续可被 Web、Scheduling、Collection、Computation 复用。
+
+## Consumer 集成清单
+
+- [ ] 只组合语义匹配 runtime aggregate 的 fragments。
+- [ ] 在能让流程更清晰时，先填 shared defaults，再填 runtime-specific defaults。
+- [ ] Runtime-owned identity rules 留在 runtime package。
+- [ ] 用 fragment 自己的 `Validate` methods 或 `setting.Validate` 校验 shared fragments。
+- [ ] 在 aggregate 边界把 shared validation errors 和 runtime-owned validation errors 合并。
+- [ ] Runtime-specific default 或更严格的 validation rule 应记录在 shared package handbook 之外。
+
+<details>
+<summary>示例：当前 server composition</summary>
+
+`server/internal/setting.Identity` 组合了这些 shared fragments：
+
+```go
+type Identity struct {
+	Organization sharedsetting.Organization `json:"organization" yaml:"organization" mapstructure:"organization"`
+	Application  sharedsetting.Application  `json:"application" yaml:"application" mapstructure:"application"`
+	System       sharedsetting.System       `json:"system" yaml:"system" mapstructure:"system"`
+	Service      sharedsetting.Service      `json:"service" yaml:"service" mapstructure:"service"`
+	Deployment   sharedsetting.Deployment   `json:"deployment" yaml:"deployment" mapstructure:"deployment"`
+}
+```
+
+Server package 随后自己拥有 `System.Runtime` 必须为 `server` 的 server-specific rule。这条规则不是 shared package contract。
+
+</details>
+
+## 导航
+
+| 上一章 | 上级 | 下一章 |
+| --- | --- | --- |
+| [Shared config 包](../config/README.md) | Shared packages | [第 1 章：契约](contract.md) |

--- a/docs/zh-cn/handbook/shared-packages/setting/contract.md
+++ b/docs/zh-cn/handbook/shared-packages/setting/contract.md
@@ -1,0 +1,152 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/zh-cn/handbook/shared-packages/setting/contract.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# 第 1 章：Shared Setting 契约
+
+| 上一章 | 上级 | 下一章 |
+| --- | --- | --- |
+| [总览](README.md) | [Shared setting 包](README.md) | [第 2 章：模型](model.md) |
+
+> [!TIP]
+> 把这个包组合进 runtime aggregate 之前，先读本章。它定义哪些决策属于 shared package，哪些决策必须留在 runtime-owned code。
+
+## 契约摘要
+
+`packages/shared/setting` 负责可复用的 identity 和 deployment fragments。它不负责 concrete runtime setting aggregate。
+
+| 契约区域 | 包责任 | 调用方责任 |
+| --- | --- | --- |
+| Runtime values | 声明支持的 Dox runtime enum values。 | 决定 concrete aggregate 接受哪个 runtime value。 |
+| Environment values | 声明支持的 Dox deployment env values。 | 决定 env 如何由 bootstrap 或 deployment inputs 注入。 |
+| Fragment defaults | 填充保守的 shared defaults。 | 在 shared defaults 之后或周围添加 runtime-specific defaults。 |
+| Fragment validation | 校验 shared field syntax 和 enum values。 | 校验 runtime-specific combinations 和更严格规则。 |
+| Error shape | 返回 Dox-owned validation error types。 | 在 runtime aggregate 边界合并或转换 errors。 |
+
+## Identity 契约
+
+这个包定义 identity fragments，而不是 global identity aggregate。Runtime 可以在语义匹配时把这些 fragments 组合进自己的 group：
+
+- `Organization` 表示 ownership 和 governance identity；
+- `Application` 表示 Dox application family；
+- `System` 表示 Dox runtime identity；
+- `Service` 表示一个 logical service identity；
+- `Deployment` 表示 environment 和 deployment location。
+
+Shared package 不决定 server 必须使用 `RuntimeServer`、scheduler 必须使用 `RuntimeScheduler`，也不决定 deployment env 来自哪个 flag。Runtime packages 拥有这些决策。
+
+## Default 契约
+
+默认值刻意保守。
+
+| Fragment | Shared Default 行为 |
+| --- | --- |
+| `Organization` | 空 `Name` 变为 `opendox`。 |
+| `Application` | 空 `Name` 变为 `dox`。 |
+| `System` | 不自动发明 runtime。Runtime identity 必须显式提供，或由 consumer package 设置。 |
+| `Service` | 空 `Namespace` 变为 `Application.Name`；只有 runtime 已知时，空 `Name` 才变为 `string(System.Runtime)`。 |
+| `Deployment` | 空 `Env` 变为 `dev`。 |
+
+> [!IMPORTANT]
+> `System.Default` 按设计是 no-op。Shared package 无法安全地在 `server`、`scheduler`、`collector`、`compute` 之间替调用方做选择。
+
+## Validation 契约
+
+Validation 在 `go-playground/validator` 之上注册 Dox-owned tags。
+
+| Tag | 含义 | 当前规则 |
+| --- | --- | --- |
+| `dox_kebab` | 稳定 kebab-case 名称。 | 必须以小写字母开头，可包含小写字母、数字和单连字符分隔段。 |
+| `dox_identifier` | 稳定 infrastructure 或 governance identifier。 | 必须以小写字母或数字开头和结尾；中间可包含小写字母、数字、点、下划线和连字符。 |
+| `dox_runtime` | 支持的 Dox runtime。 | 必须是 `server`、`scheduler`、`collector` 或 `compute`。 |
+| `dox_env` | 支持的 Dox deployment environment。 | 必须是 `dev`、`test`、`staging` 或 `prod`。 |
+
+Validator 暴露字段名时，优先使用 `mapstructure` tag，然后是 `json` tag，最后是 Go field name。
+
+## Error 契约
+
+包暴露：
+
+- `FieldError`，包含 `Field` 和 `Rule`；
+- `ValidationError`，包含 `Fields []FieldError`；
+- `Validate(value any) error`，返回 nil 或 `ValidationError`。
+
+调用方应把 `ValidationError.Fields` 当作机器可读契约。Error string 适合日志，但需要字段级处理时不应该解析字符串。
+
+<details>
+<summary>示例：validation field shape</summary>
+
+非法 system runtime 会产生类似这样的 field entry：
+
+```text
+Field: System.runtime
+Rule: dox_runtime
+```
+
+`runtime` 字段名来自 `mapstructure:"runtime"` tag。
+
+</details>
+
+## Runtime 边界
+
+Runtime packages 组合 shared fragments，然后添加 runtime policy。
+
+```mermaid
+sequenceDiagram
+    participant Shared as packages/shared/setting
+    participant Runtime as runtime/internal/setting
+    participant Bootstrap as runtime bootstrap
+
+    Runtime->>Shared: call fragment Default methods
+    Runtime->>Runtime: apply runtime-specific defaults
+    Runtime->>Shared: call fragment Validate methods
+    Runtime->>Runtime: validate runtime-owned combinations
+    Bootstrap->>Runtime: consume concrete aggregate
+```
+
+当前 server 行为只是 consumer 示例：
+
+- server 组合 shared identity fragments；
+- server 把缺失的 `System.Runtime` 默认成 `server`；
+- server 拒绝合法但不是 server 的 runtime value；
+- server 可以从 bootstrap options 注入 `Deployment.Env`。
+
+这些规则记录为 server behavior，而不是 shared package behavior。
+
+## 契约之外
+
+以下内容不属于 shared setting contract：
+
+- root runtime `Setting` structs；
+- config source loading 或 decoding；
+- logging configuration；
+- HTTP、database、queue、plugin 或 security setting groups；
+- service registry 或 deployment manifest schemas；
+- runtime bootstrap、lifecycle 或 subsystem wiring；
+- 为所有 consumers 选择 runtime identity；
+- 从环境变量创建 process-wide defaults。
+
+## 导航
+
+| 上一章 | 上级 | 下一章 |
+| --- | --- | --- |
+| [总览](README.md) | [Shared setting 包](README.md) | [第 2 章：模型](model.md) |

--- a/docs/zh-cn/handbook/shared-packages/setting/functions.md
+++ b/docs/zh-cn/handbook/shared-packages/setting/functions.md
@@ -1,0 +1,182 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/zh-cn/handbook/shared-packages/setting/functions.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# 第 3 章：Shared Setting 函数与 API
+
+| 上一章 | 上级 | 下一章 |
+| --- | --- | --- |
+| [第 2 章：模型](model.md) | [Shared setting 包](README.md) | 结束 |
+
+> [!NOTE]
+> 本章是这个包的 API reference。如果某个行为依赖模型语义，相关模型章节会在正文中链接。
+
+## 常量
+
+| API | Value | 用途 |
+| --- | --- | --- |
+| `DefaultOrganizationName` | `opendox` | 默认 organization identity。 |
+| `DefaultApplicationName` | `dox` | 默认 product 或 application family identity。 |
+
+## Runtime API
+
+| API | 用途 |
+| --- | --- |
+| `type Runtime string` | Dox runtime identity value。 |
+| `RuntimeServer` | Web backend runtime。 |
+| `RuntimeScheduler` | Scheduling runtime。 |
+| `RuntimeCollector` | Collection runtime。 |
+| `RuntimeCompute` | Computation runtime。 |
+| `(Runtime).IsValid() bool` | 对支持的 runtime value 返回 true。 |
+
+Runtime validation 是 shared 的，但 runtime selection 不是。比如 server package 可以要求 `RuntimeServer`，scheduler package 应该要求 `RuntimeScheduler`。
+
+## Env API
+
+| API | 用途 |
+| --- | --- |
+| `type Env string` | Deployment environment value。 |
+| `EnvDev` | Development environment。 |
+| `EnvTest` | Test environment。 |
+| `EnvStaging` | Staging environment。 |
+| `EnvProd` | Production environment。 |
+| `(Env).IsValid() bool` | 对支持的 environment value 返回 true。 |
+
+## Fragment API
+
+| Fragment | Default Method | Validate Method |
+| --- | --- | --- |
+| `Organization` | `(*Organization).Default() error` | `(Organization).Validate() error` |
+| `Application` | `(*Application).Default() error` | `(Application).Validate() error` |
+| `System` | `(*System).Default() error` | `(System).Validate() error` |
+| `Service` | `(*Service).Default(application, system) error` | `(Service).Validate() error` |
+| `Deployment` | `(*Deployment).Default() error` | `(Deployment).Validate() error` |
+
+Default methods 在 nil receiver 上会返回 error。Validate methods 调用 package-level `Validate` helper。
+
+## Default Method 行为
+
+| Method | 行为 |
+| --- | --- |
+| `Organization.Default` | 把空 `Name` 设置为 `DefaultOrganizationName`。 |
+| `Application.Default` | 把空 `Name` 设置为 `DefaultApplicationName`。 |
+| `System.Default` | 只检查 receiver，不设置 `Runtime`。 |
+| `Service.Default` | 从 `application.Name` 设置空 `Namespace`；runtime 已知时从 `system.Runtime` 设置空 `Name`。 |
+| `Deployment.Default` | 把空 `Env` 设置为 `EnvDev`。 |
+
+<details>
+<summary>示例：runtime aggregate 中的 default 顺序</summary>
+
+```go
+func (i *Identity) Default() error {
+	if err := i.Organization.Default(); err != nil {
+		return err
+	}
+	if err := i.Application.Default(); err != nil {
+		return err
+	}
+	if err := i.System.Default(); err != nil {
+		return err
+	}
+	if i.System.Runtime == "" {
+		i.System.Runtime = sharedsetting.RuntimeServer
+	}
+	if err := i.Service.Default(i.Application, i.System); err != nil {
+		return err
+	}
+	return i.Deployment.Default()
+}
+```
+
+设置 `RuntimeServer` 的那一行由 runtime package 自己拥有。
+
+</details>
+
+## Validation API
+
+| API | 用途 |
+| --- | --- |
+| `Validate(value any) error` | 使用已注册的 Dox validation tags 校验 struct。 |
+| `FieldError` | 带 `Field` 和 `Rule` 的机器可读字段失败。 |
+| `ValidationError` | 字段失败列表。 |
+| `(*ValidationError).Error() string` | 适合日志的紧凑 error message。 |
+
+Validation engine 初始化一次，并注册：
+
+- `dox_kebab`;
+- `dox_identifier`;
+- `dox_runtime`;
+- `dox_env`.
+
+字段名优先来自 `mapstructure` tags。这能让 validation output 与 decoded configuration keys 对齐。
+
+## 调用方 Recipes
+
+### 组合 runtime identity group
+
+定义 runtime-owned group，用 shared fragments 作为字段或嵌入。不要把 `packages/shared/setting` 暴露成整个 runtime setting aggregate。
+
+### 添加 runtime-specific validation
+
+把 shared validation 和 runtime-specific validation 合并：
+
+```go
+func (i Identity) Validate() error {
+	return errors.Join(
+		i.Organization.Validate(),
+		i.Application.Validate(),
+		i.System.Validate(),
+		i.validateServerRuntime(),
+		i.Service.Validate(),
+		i.Deployment.Validate(),
+	)
+}
+```
+
+### 保持 runtime bootstrap 分离
+
+Bootstrap 可以提供 env、instance ID 或 region 等 seed values。Shared package 不应该直接读取 flags、environment variables、files 或 process metadata。
+
+## 调用方责任
+
+每个 runtime consumer 必须自己拥有：
+
+- root `Setting` aggregate；
+- group composition；
+- runtime identity selection；
+- runtime-specific defaults；
+- 依赖多个 fragments 组合关系的 validation；
+- bootstrap-derived seed values；
+- 更严格 runtime behavior 的文档。
+
+## API 稳定性备注
+
+- Shared fragments 设计目标是在 Dox runtimes 之间复用。
+- Validation tags 是 public package behavior 的一部分。
+- 第三方 validator 实现不会作为 caller-facing error type 暴露。
+- 新增 runtime 或 environment value 会改变 shared validation semantics，应视为契约变更。
+
+## 导航
+
+| 上一章 | 上级 | 下一章 |
+| --- | --- | --- |
+| [第 2 章：模型](model.md) | [Shared setting 包](README.md) | 结束 |

--- a/docs/zh-cn/handbook/shared-packages/setting/model.md
+++ b/docs/zh-cn/handbook/shared-packages/setting/model.md
@@ -1,0 +1,185 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/zh-cn/handbook/shared-packages/setting/model.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# 第 2 章：Shared Setting 模型
+
+| 上一章 | 上级 | 下一章 |
+| --- | --- | --- |
+| [第 1 章：契约](contract.md) | [Shared setting 包](README.md) | [第 3 章：函数与 API](functions.md) |
+
+> [!NOTE]
+> 本章描述数据形状。方法行为和导出 helper 见 [第 3 章](functions.md)。
+
+## 模型图
+
+```mermaid
+classDiagram
+    class Organization {
+        string Name
+        string Owner
+        string CostCenter
+        string Project
+    }
+    class Application {
+        string Name
+    }
+    class System {
+        Runtime Runtime
+    }
+    class Service {
+        string Namespace
+        string Name
+        string InstanceID
+    }
+    class Deployment {
+        Env Env
+        string Region
+        string Zone
+        string Cluster
+        string K8sNamespace
+    }
+    Application --> Service : default namespace
+    System --> Service : default name
+```
+
+包导出的是独立 fragments。它不导出把这些 fragments 绑定在一起的 root aggregate。
+
+## Runtime
+
+`Runtime` 标识一个 Dox runtime system。
+
+| Constant | Value | 含义 |
+| --- | --- | --- |
+| `RuntimeServer` | `server` | Web backend runtime。 |
+| `RuntimeScheduler` | `scheduler` | Scheduling runtime。 |
+| `RuntimeCollector` | `collector` | Collection runtime。 |
+| `RuntimeCompute` | `compute` | Computation runtime。 |
+
+使用 `Runtime.IsValid()` 检查某个值是否是支持的 Dox runtime name。
+
+## Env
+
+`Env` 标识 deployment environment。
+
+| Constant | Value | 含义 |
+| --- | --- | --- |
+| `EnvDev` | `dev` | Development environment。 |
+| `EnvTest` | `test` | Test environment。 |
+| `EnvStaging` | `staging` | Staging environment。 |
+| `EnvProd` | `prod` | Production environment。 |
+
+使用 `Env.IsValid()` 检查某个值是否是支持的 Dox environment name。
+
+## Organization
+
+`Organization` 描述 shared ownership 和 governance identity。
+
+| Field | Tags | Default | Validation | 意图 |
+| --- | --- | --- | --- | --- |
+| `Name` | `json/yaml/mapstructure:"name"` | 空值时为 `opendox` | `required,dox_identifier` | Organization identity。 |
+| `Owner` | `owner` | 空 | `omitempty,dox_identifier` | Owning team 或 owner code。 |
+| `CostCenter` | `cost_center` | 空 | `omitempty,dox_identifier` | Cost allocation code。 |
+| `Project` | `project` | 空 | `omitempty,dox_identifier` | Project identity。 |
+
+这些值应该稳定并对机器友好。人类展示名称属于 runtime 或 product metadata，不属于这个 fragment。
+
+## Application
+
+`Application` 描述 product 或 application family identity。
+
+| Field | Tags | Default | Validation | 意图 |
+| --- | --- | --- | --- | --- |
+| `Name` | `json/yaml/mapstructure:"name"` | 空值时为 `dox` | `required,dox_kebab` | Dox application family name。 |
+
+这个值可以通过 `Service.Default` 注入 `Service.Namespace`。
+
+## System
+
+`System` 描述 runtime 的 Dox core system identity。
+
+| Field | Tags | Default | Validation | 意图 |
+| --- | --- | --- | --- | --- |
+| `Runtime` | `json/yaml/mapstructure:"runtime"` | 无 | `required,dox_runtime` | Runtime system identity。 |
+
+`System.Default` 刻意不设置 `Runtime`。Concrete runtime packages 应在自己拥有足够上下文时设置它。
+
+## Service
+
+`Service` 描述一个 logical service identity。
+
+| Field | Tags | Default | Validation | 意图 |
+| --- | --- | --- | --- | --- |
+| `Namespace` | `json/yaml/mapstructure:"namespace"` | 空值时为 `Application.Name` | `required,dox_kebab` | Service namespace。 |
+| `Name` | `json/yaml/mapstructure:"name"` | 空值且 runtime 已知时为 `string(System.Runtime)` | `required,dox_kebab` | Logical service name。 |
+| `InstanceID` | `json/yaml/mapstructure:"instance_id"` | 空 | `omitempty,dox_identifier` | 具体 process、pod、node 或 deployment instance。 |
+
+当调用方明确建模多个 logical services 运行在同一个 process 或 pod 中时，services 可以共享 `InstanceID`。
+
+## Deployment
+
+`Deployment` 描述 runtime 或 service 部署在哪里。
+
+| Field | Tags | Default | Validation | 意图 |
+| --- | --- | --- | --- | --- |
+| `Env` | `json/yaml/mapstructure:"env"` | 空值时为 `dev` | `required,dox_env` | Deployment environment。 |
+| `Region` | `region` | 空 | `omitempty,dox_identifier` | Cloud 或 operational region。 |
+| `Zone` | `zone` | 空 | `omitempty,dox_identifier` | Availability zone 或等价 placement。 |
+| `Cluster` | `cluster` | 空 | `omitempty,dox_identifier` | Cluster identity。 |
+| `K8sNamespace` | `k8s_namespace` | 空 | `omitempty,dox_identifier` | Kubernetes namespace。 |
+
+`Deployment.Default` 只设置 `EnvDev`。它不会发明 region、zone、cluster 或 namespace。
+
+## Validation Rule 细节
+
+| Rule | 接受 | 拒绝 |
+| --- | --- | --- |
+| `dox_kebab` | `dox`, `dox-server`, `iam-service` | `Dox`, `dox_iam`, `iam-service-` |
+| `dox_identifier` | `opendox`, `us-east-1`, `server_pod.1` | `Platform Team`, `dox-prod-`, `_hidden` |
+| `dox_runtime` | `server`, `scheduler`, `collector`, `compute` | `worker`, `queue`, `api` |
+| `dox_env` | `dev`, `test`, `staging`, `prod` | `stage`, `production`, `local` |
+
+> [!WARNING]
+> Validation rules 更偏向稳定 identifier，而不是人类可读 label。如果需要面向用户的名称，应放在另一个 model 中。
+
+## 当前 Consumer 关系
+
+当前 server setting package 这样组合 shared fragments：
+
+```mermaid
+flowchart TD
+    org["setting.Organization"] --> identity["server/internal/setting.Identity"]
+    app["setting.Application"] --> identity
+    system["setting.System"] --> identity
+    service["setting.Service"] --> identity
+    deployment["setting.Deployment"] --> identity
+    identity --> root["server/internal/setting.Setting"]
+    logging["packages/shared/logging.Config"] --> root
+```
+
+这个图只是 consumer 示例。Shared package 仍然只导出独立 fragments。
+
+## 导航
+
+| 上一章 | 上级 | 下一章 |
+| --- | --- | --- |
+| [第 1 章：契约](contract.md) | [Shared setting 包](README.md) | [第 3 章：函数与 API](functions.md) |


### PR DESCRIPTION
## Description

Adds a bilingual, book-style engineering handbook for the shared setting package. The docs establish `packages/shared/setting` as the reusable identity and deployment fragment reference for future Web, Scheduling, Collection, and Computation engineering manuals.

This PR intentionally changes documentation only. It keeps the shared package boundary explicit: shared setting owns fragments, defaults, enums, and validation helpers, while concrete runtime packages own root aggregates, runtime-specific defaults, and stricter aggregate rules.

## Related Links

- Closes #39
- Refs #38

## Scope

- [ ] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [x] Security
- [x] Backend

## Implementation Notes

- Adds English handbook pages under `docs/en-us/handbook/shared-packages/setting/`.
- Adds Chinese handbook pages under `docs/zh-cn/handbook/shared-packages/setting/`.
- Structures the handbook as sequential chapters with previous/up/next navigation.
- Documents package contract, shared fragment model, validation tags, exported methods, and runtime consumer boundaries.
- Uses GitHub-flavored Markdown callouts, Mermaid diagrams, field tables, checklists, and details examples to make the handbook read as a module book instead of isolated reference pages.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands run:

```sh
git diff --check
git diff --cached --check
```

Not run:

```sh
go test ./packages/shared/setting
```

The current environment does not have a `go` binary on `PATH`, so Go package tests could not be executed locally for this docs-only PR.

## Risks

This establishes a richer book-style pattern than the first config handbook PR. If accepted, the logging handbook should follow this style, and the config handbook can be polished in a separate docs issue rather than mixed into this setting issue.
