### PR TITLE
gh-40 [docs]: Add shared logging package handbook

### DIFF
--- a/docs/en-us/handbook/shared-packages/logging/README.md
+++ b/docs/en-us/handbook/shared-packages/logging/README.md
@@ -1,0 +1,127 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/en-us/handbook/shared-packages/logging/README.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Logging Package Reference
+
+`packages/shared/logging` defines the shared Dox logging model, configuration contract, logger facade, zap core helpers, and OpenTelemetry SDK helpers.
+
+This reference is designed for formal engineering manuals to link into. It is not a linear tutorial. Each page is self-contained and answers a specific kind of implementation question.
+
+> [!IMPORTANT]
+> Runtime packages may reference this package, but runtime bootstrap still owns logger construction, OpenTelemetry global installation, HTTP middleware wiring, scheduler/collector/compute integration, and deployment-specific output policy.
+
+## Reference Map
+
+| Page | Use it when you need to know |
+| --- | --- |
+| [Contract](contract.md) | What the package guarantees, what it does not implement, and how config validation/error semantics work. |
+| [Model](model.md) | How resource, correlation, event, node, tags, and fields should be shaped in log records. |
+| [Runtime Boundary](runtime-boundary.md) | What the zap core base and OpenTelemetry SDK base build, and which runtime responsibilities remain outside the package. |
+| [Functions and API](functions.md) | Which exported types, constructors, helpers, and constants are available to callers. |
+
+## Package Position
+
+```mermaid
+flowchart TD
+    runtime["runtime setting aggregate"] --> config["logging.Config"]
+    config --> zapbase["ZapCoreBase<br/>zap core helpers"]
+    config --> otelbase["OpenTelemetrySDKBase<br/>SDK provider helpers"]
+    zapbase --> facade["logging.Logger facade"]
+    otelbase --> bootstrap["runtime bootstrap"]
+    facade --> business["business code"]
+    bootstrap --> globals["optional runtime globals<br/>not installed by this package"]
+```
+
+Business code should depend on `logging.Logger` and `logging.Attr`. Runtime bootstrap code may use `ZapCoreBase` and `OpenTelemetrySDKBase`.
+
+## Current Capability Matrix
+
+| Area | Current Status |
+| --- | --- |
+| Config shape | Implemented with defaults, JSON/YAML/mapstructure tags, and validation. |
+| Logger facade | Implemented with Dox-owned `Logger` and `Attr` APIs that hide zap types from business-facing signatures. |
+| Context correlation | Implemented with context storage, overlay merge, and log-call merge behavior. |
+| Zap console core | Implemented. |
+| Zap JSON file core | Implemented. |
+| Lumberjack rotation | Implemented for single-path file cores. |
+| OpenTelemetry resource | Implemented and merged over SDK defaults. |
+| OpenTelemetry propagator | Implemented for trace context and baggage. |
+| OpenTelemetry SDK providers | Implemented for traces, metrics, and logs when enabled. |
+| OpenTelemetry global installation | Not implemented by this package. |
+| OTLP exporter setup | Not implemented; enabling it is rejected by the SDK base. |
+| Dataset routing | Configured and validated, but not applied to core routing yet. |
+| Buffering | Configured and validated, but no buffered writer is installed yet. |
+| Redaction | Configured and validated, but no field/value redaction is applied yet. |
+| Default file path template rendering | Not implemented; the template is currently passed as a literal output path. |
+
+## Default Configuration Shape
+
+The default configuration creates a console core and a JSONL file core:
+
+```yaml
+level: info
+cores:
+  - name: console
+    enabled: true
+    type: console
+    level: info
+    encoding: console
+    output_paths: ["stdout"]
+    datasets: ["*"]
+  - name: service-file
+    enabled: true
+    type: file
+    level: info
+    encoding: json
+    output_paths: ["logs/${service.namespace}-${service.name}.jsonl"]
+    datasets: ["*"]
+    rotation:
+      driver: lumberjack
+      enabled: true
+      max_size_mb: 100
+      max_backups: 10
+      max_age_days: 14
+      compress: true
+      local_time: true
+```
+
+> [!WARNING]
+> `logs/${service.namespace}-${service.name}.jsonl` is currently a string default, not a rendered template. Runtime bootstrap or a later package change must render it before a dynamic service-specific path exists.
+
+## Formal Documentation Use
+
+System manuals should link to this reference instead of copying package behavior. Good link targets include:
+
+- `logging.Config` defaults and validation rules;
+- the log record model for resource/correlation/event fields;
+- the zap and OpenTelemetry runtime boundary;
+- the explicit unsupported behavior matrix.
+
+Manuals for Web, Scheduling, Collection, and Computation should document their own bootstrap choices separately, such as output paths, global provider installation, middleware correlation, and deployment collectors.
+
+## Related References
+
+- [Shared config package](../config/README.md)
+- [Shared setting package](../setting/README.md)
+- Package source: `packages/shared/logging`
+- Current server consumer: `server/internal/setting`

--- a/docs/en-us/handbook/shared-packages/logging/contract.md
+++ b/docs/en-us/handbook/shared-packages/logging/contract.md
@@ -1,0 +1,157 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/en-us/handbook/shared-packages/logging/contract.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Logging Contract
+
+This page answers what callers can rely on from `packages/shared/logging`, which behavior is only configuration shape today, and which errors are part of the package contract.
+
+## Ownership Contract
+
+| Area | Package Owns | Runtime Owns |
+| --- | --- | --- |
+| Logging vocabulary | Resource, correlation, event, node, tags, and fields model. | Runtime-specific naming policy and business event taxonomy. |
+| Business logging API | `Logger`, `Attr`, and typed attribute constructors. | Passing the facade to services and middleware. |
+| zap mapping | Level, encoder, config, console core, JSON/file core, lumberjack helpers. | Choosing output paths, lifecycle, deployment topology, and sink ownership. |
+| OpenTelemetry SDK base | Resource mapping, propagator mapping, SDK provider construction, flush/shutdown helpers. | Installing globals, exporter wiring, and lifecycle integration. |
+| Config validation | Defaults and package validation errors. | Runtime-specific configuration restrictions and environment-specific policy. |
+
+> [!NOTE]
+> The package is a shared foundation. It deliberately does not start logging for any process on its own.
+
+## Config Contract
+
+`Config` is the root shared logging configuration shape.
+
+| Group | Purpose |
+| --- | --- |
+| `Level` | Root Dox logging level. |
+| `Development` | Root development-mode switch that feeds zap defaults. |
+| `Resource` | Logging-specific resource overrides, currently `service_version`. |
+| `Zap` | zap-facing config shape and encoder symbols. |
+| `Cores` | Console/file core declarations. |
+| `Buffering` | Future buffered writer behavior. |
+| `Shutdown` | Flush/shutdown timeout. |
+| `Redaction` | Sensitive key replacement policy shape. |
+| `OTel` | OpenTelemetry propagation, provider, exporter, and batch settings. |
+
+`Config.Default` fills defaults before validation. `Config.Validate` checks supported enum values, required paths, duplicate core names, positive durations and sizes, redaction key shape, OTLP protocol shape, and batch constraints.
+
+## Default Contract
+
+| Field | Default |
+| --- | --- |
+| Root level | `info` |
+| zap encoding | `json` |
+| zap output paths | `stdout` |
+| zap error output paths | `stderr` |
+| encoder message key | `message` |
+| encoder level key | `severity_text` |
+| encoder time key | `timestamp` |
+| buffering | enabled, `262144` bytes, `1s` flush interval |
+| shutdown timeout | `5s` |
+| redaction | enabled, `[REDACTED]`, default sensitive keys |
+| OpenTelemetry | root/traces/metrics/logs enabled, trace context and baggage enabled |
+| OTLP exporter | disabled by default |
+
+Explicit disabled pointer toggles remain disabled after defaults are applied.
+
+## Validation Error Contract
+
+The package exposes:
+
+- `FieldError`, with `Field` and `Reason`;
+- `ValidationError`, with `Fields []FieldError`;
+- compact error strings for logs.
+
+Callers should inspect `ValidationError.Fields` instead of parsing error strings.
+
+<details>
+<summary>Example validation fields</summary>
+
+```text
+level: level is not supported
+cores[1].name: core name must be unique
+redaction.keys[0]: redaction key must not be empty
+otel.traces.sampler.ratio: trace sampler ratio must be between 0 and 1
+```
+
+</details>
+
+## Implemented Versus Contract-Only Settings
+
+| Setting | Validation | Runtime Effect Today |
+| --- | --- | --- |
+| `cores[].datasets` | Validated as non-empty entries. | Not used for event dataset routing yet. |
+| `buffering.*` | Validated when enabled. | No buffered writer is installed yet. |
+| `redaction.*` | Validated when enabled. | No log field or value redaction is applied yet. |
+| `cores[].rotation.driver=external/logrotate` | Valid enum value. | Rejected by the current zap file sink. |
+| `otel.exporter.otlp.*` | Shape is validated. | Enabled OTLP exporter is rejected by `NewOpenTelemetrySDKBase`. |
+| `zap.sampling.hook_metrics` | Part of config shape. | No sampling hook metrics are installed yet. |
+| `DefaultFilePathTemplate` | Used as default string. | Template variables are not rendered. |
+
+> [!WARNING]
+> Treat contract-only settings as forward-compatible schema, not as active runtime behavior.
+
+## Logger Contract
+
+Business-facing code uses `Logger` and `Attr`.
+
+The facade guarantees:
+
+- log level methods: `Debug`, `Info`, `Warn`, `Error`, `DPanic`, `Panic`, `Fatal`;
+- logger derivation: `Named`, `With`;
+- flush path: `Sync`;
+- Dox-owned attributes for resource, correlation, event, node, tags, fields, single fields, and errors;
+- context correlation merge on every write.
+
+The facade deliberately does not expose `zap.Logger` or `zap.Field` in method signatures.
+
+## Context Correlation Contract
+
+Correlation helpers provide simple overlay semantics:
+
+- `ContextWithCorrelation` stores a correlation value and accepts nil context by using `context.Background`.
+- `ContextWithMergedCorrelation` merges non-empty overlay fields into existing context correlation.
+- `CorrelationFromContext` returns `(Correlation, false)` for nil or missing context.
+- `MergeCorrelation` keeps base fields unless overlay fields are non-empty.
+
+## Out of Contract
+
+The following behavior is outside the package contract today:
+
+- opening runtime loggers during server/scheduler/collector/compute startup;
+- HTTP middleware correlation;
+- task/job/plugin correlation injection;
+- OpenTelemetry global provider installation;
+- OTLP exporter construction;
+- collector deployment examples;
+- runtime-specific sink path rendering;
+- multi-process rotation coordination;
+- field-level redaction execution;
+- dataset-based core routing.
+
+## Related References
+
+- [Model](model.md)
+- [Runtime Boundary](runtime-boundary.md)
+- [Functions and API](functions.md)

--- a/docs/en-us/handbook/shared-packages/logging/functions.md
+++ b/docs/en-us/handbook/shared-packages/logging/functions.md
@@ -1,0 +1,154 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/en-us/handbook/shared-packages/logging/functions.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Logging Functions and API
+
+This page answers which exported logging APIs callers can use and what each API is for.
+
+## Constants and Enums
+
+| API | Purpose |
+| --- | --- |
+| `DefaultFilePathTemplate` | Default JSONL file path string. Currently not rendered by the package. |
+| `DefaultRedactionReplacement` | Default replacement string for redaction config. |
+| `Level` and level constants | Dox logging levels: debug, info, warn, error, dpanic, panic, fatal. |
+| `Encoding` and encoding constants | Supported encodings: console and json. |
+| `CoreType` and core constants | Supported core types: console and file. |
+| `RotationDriver` and driver constants | Rotation strategy values: lumberjack, external, logrotate, none. |
+| `OTLPProtocol` and protocol constants | OTLP protocol values: grpc and http. |
+| `TraceSamplerType` and sampler constants | OpenTelemetry sampler shape values. |
+
+Every enum type has an `IsValid` method.
+
+## Config API
+
+| API | Purpose |
+| --- | --- |
+| `Config.Default() error` | Applies shared logging defaults. |
+| `Config.Validate() error` | Validates the shared logging configuration contract. |
+| `DefaultRedactionKeys() []string` | Returns the default sensitive key list. |
+
+Most nested config structs have `Default` methods used by `Config.Default`; callers normally call defaults on the root config.
+
+## Model API
+
+| Type | Purpose |
+| --- | --- |
+| `Resource` | Telemetry producer identity. |
+| `Correlation` | Request/task/workflow/plugin correlation identity. |
+| `Event` | Observability event classification. |
+| `Node` | Service-internal component and operation. |
+| `Tags` | Low-cardinality business labels. |
+| `Fields` | Higher-cardinality event facts. |
+
+Field name constants in `fields.go` define the stable output keys.
+
+## Logger API
+
+| API | Purpose |
+| --- | --- |
+| `Logger` | Business-facing logging facade. |
+| `Attr` | Opaque attribute application type. |
+| `NewLogger(base, attrs...)` | Wraps a `ZapCoreBase` in the Dox logger facade. |
+| `ResourceAttr` | Adds resource fields. |
+| `CorrelationAttr` | Adds correlation fields. |
+| `EventAttr` | Adds event fields. |
+| `NodeAttr` | Adds component and operation fields. |
+| `TagsAttr` | Adds tags object entries. |
+| `FieldsAttr` | Adds fields object entries. |
+| `FieldAttr` | Adds one fields object entry. |
+| `ErrorAttr` | Adds one error field. |
+
+`NewLogger` rejects a nil `ZapCoreBase`. Logger facade method signatures do not expose zap types.
+
+## Context API
+
+| API | Purpose |
+| --- | --- |
+| `ContextWithCorrelation(ctx, correlation)` | Stores correlation on context. |
+| `ContextWithMergedCorrelation(ctx, correlation)` | Merges non-empty fields into context correlation. |
+| `CorrelationFromContext(ctx)` | Retrieves correlation and a boolean. |
+| `MergeCorrelation(base, overlay)` | Applies non-empty overlay fields to base. |
+
+Nil context is handled safely by the helper functions.
+
+## Zap API
+
+| API | Purpose |
+| --- | --- |
+| `ZapCoreBase` | Runtime-owned zap primitives and close lifecycle. |
+| `NewZapLevel(level)` | Maps Dox level to zapcore level. |
+| `NewZapAtomicLevel(level)` | Creates zap atomic level. |
+| `NewZapEncoderConfig(config)` | Maps symbolic encoder config to zapcore encoder config. |
+| `NewZapConfig(config)` | Maps Dox config to zap config. |
+| `NewZapCoreBase(config)` | Builds enabled zap cores and zap options. |
+| `(*ZapCoreBase).Options()` | Returns copied zap options. |
+| `(*ZapCoreBase).Close()` | Closes opened sinks once. |
+
+Runtime bootstrap should own `ZapCoreBase` lifecycle and should avoid exposing zap primitives to business code.
+
+## OpenTelemetry API
+
+| API | Purpose |
+| --- | --- |
+| `OpenTelemetrySDKBase` | Runtime-owned OpenTelemetry SDK primitives. |
+| `NewOpenTelemetrySDKBase(config, resource)` | Builds resource, propagator, and enabled providers. |
+| `NewOpenTelemetryResource(model, config)` | Maps Dox resource to SDK resource. |
+| `NewOpenTelemetryPropagator(config)` | Builds trace context/baggage propagator. |
+| `NewOpenTelemetryTraceSampler(config)` | Builds SDK trace sampler. |
+| `(*OpenTelemetrySDKBase).ForceFlush(ctx)` | Flushes enabled SDK providers. |
+| `(*OpenTelemetrySDKBase).Shutdown(ctx)` | Shuts down enabled SDK providers. |
+
+The SDK base returns provider objects. It does not install globals or exporters.
+
+## Runtime Integration Sketch
+
+```go
+cfg := logging.Config{}
+if err := cfg.Default(); err != nil {
+	return err
+}
+if err := cfg.Validate(); err != nil {
+	return err
+}
+
+zapBase, err := logging.NewZapCoreBase(cfg)
+if err != nil {
+	return err
+}
+defer zapBase.Close()
+
+logger, err := logging.NewLogger(zapBase, logging.ResourceAttr(resource))
+if err != nil {
+	return err
+}
+defer logger.Sync()
+```
+
+This sketch omits runtime policy such as path rendering, global OpenTelemetry installation, and shutdown orchestration.
+
+## Related References
+
+- [Contract](contract.md)
+- [Model](model.md)
+- [Runtime Boundary](runtime-boundary.md)

--- a/docs/en-us/handbook/shared-packages/logging/model.md
+++ b/docs/en-us/handbook/shared-packages/logging/model.md
@@ -1,0 +1,194 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/en-us/handbook/shared-packages/logging/model.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Logging Model
+
+This page answers how Dox log records should describe the producer, execution chain, observed event, internal node, tags, and detailed fields.
+
+## Model Map
+
+```mermaid
+classDiagram
+    class Resource {
+        service namespace/name/instance/version
+        deployment environment
+        cloud and k8s placement
+        Dox organization/application/runtime
+    }
+    class Correlation {
+        trace/span flags
+        request/correlation IDs
+        job/task/workflow IDs
+        plugin IDs
+    }
+    class Event {
+        name
+        dataset
+        category
+        type
+        action
+        outcome
+    }
+    class Node {
+        component
+        operation
+    }
+    class Tags
+    class Fields
+    Resource --> Event : produced by
+    Correlation --> Event : connects
+    Node --> Event : happened in
+    Tags --> Event : low-cardinality labels
+    Fields --> Event : event facts
+```
+
+## Resource
+
+Resource fields answer who produced telemetry.
+
+| Field Constant | JSON Field | Meaning |
+| --- | --- | --- |
+| `FieldServiceNamespace` | `service.namespace` | Service namespace, often `dox`. |
+| `FieldServiceName` | `service.name` | Service capability name, not necessarily runtime. |
+| `FieldServiceInstanceID` | `service.instance.id` | Process, pod, node, or instance identity. |
+| `FieldServiceVersion` | `service.version` | Deployed service version. |
+| `FieldDeploymentEnvironmentName` | `deployment.environment.name` | Deployment env such as `prod`. |
+| `FieldCloudRegion` | `cloud.region` | Cloud region. |
+| `FieldCloudAvailabilityZone` | `cloud.availability_zone` | Cloud availability zone. |
+| `FieldK8sClusterName` | `k8s.cluster.name` | Kubernetes cluster. |
+| `FieldK8sNamespaceName` | `k8s.namespace.name` | Kubernetes namespace. |
+| `FieldDoxOrganization` | `dox.organization` | Dox owner organization. |
+| `FieldDoxApplication` | `dox.application` | Dox application family. |
+| `FieldDoxRuntime` | `dox.runtime` | Dox runtime: `server`, `scheduler`, `collector`, or `compute`. |
+
+> [!TIP]
+> `service.name` identifies a service capability. `dox.runtime` identifies the runtime process family. A `server` runtime can host an `iam` service.
+
+## Correlation
+
+Correlation fields connect one request, job, task, workflow, plugin run, or cross-runtime chain.
+
+| Field Constant | JSON Field |
+| --- | --- |
+| `FieldTraceID` | `trace_id` |
+| `FieldSpanID` | `span_id` |
+| `FieldTraceFlags` | `trace_flags` |
+| `FieldRequestID` | `request_id` |
+| `FieldCorrelationID` | `correlation_id` |
+| `FieldJobID` | `job_id` |
+| `FieldTaskID` | `task_id` |
+| `FieldWorkflowID` | `workflow_id` |
+| `FieldPluginID` | `plugin_id` |
+| `FieldPluginRunID` | `plugin_run_id` |
+
+`trace_id`, `span_id`, and `trace_flags` align with OpenTelemetry. `correlation_id` is Dox-owned and should survive across request, task, event, and plugin boundaries.
+
+## Event
+
+Event fields describe what the log record observes.
+
+| Field Constant | JSON Field | Example |
+| --- | --- | --- |
+| `FieldEventName` | `event.name` | `iam.login.rejected` |
+| `FieldEventDataset` | `event.dataset` | `dox.iam.security` |
+| `FieldEventCategory` | `event.category` | `authentication` |
+| `FieldEventType` | `event.type` | `denied` |
+| `FieldEventAction` | `event.action` | `login` |
+| `FieldEventOutcome` | `event.outcome` | `failure` |
+
+There is no first-class `channel` field. Dataset, category, type, action, and outcome carry event classification.
+
+## Node
+
+Node fields describe where inside a service an event happened.
+
+| Field Constant | JSON Field | Meaning |
+| --- | --- | --- |
+| `FieldComponent` | `component` | Internal component such as `auth_service`. |
+| `FieldOperation` | `operation` | Operation such as `verify_credential`. |
+
+## Tags and Fields
+
+`Tags` are low-cardinality business labels declared by the current node. `Fields` are event facts and higher-cardinality details.
+
+| Use `tags` For | Use `fields` For |
+| --- | --- |
+| `risk_level` | `account` |
+| `login_method` | `tenant_id` |
+| `credential_type` | `client_ip` |
+| `reject_reason` | `failed_attempts` |
+| `queue` | raw IDs and measured facts |
+
+Do not put resource fields, correlation IDs, or verbose error text into `tags`.
+
+<details>
+<summary>Example: IAM login rejected record</summary>
+
+```json
+{
+  "service.namespace": "dox",
+  "service.name": "iam",
+  "dox.runtime": "server",
+  "deployment.environment.name": "prod",
+  "trace_id": "trace_001",
+  "request_id": "req_001",
+  "correlation_id": "corr_001",
+  "event.name": "iam.login.rejected",
+  "event.dataset": "dox.iam.security",
+  "event.category": "authentication",
+  "event.type": "denied",
+  "event.action": "login",
+  "event.outcome": "failure",
+  "component": "auth_service",
+  "operation": "verify_credential",
+  "tags": {
+    "risk_level": "medium",
+    "login_method": "password",
+    "reject_reason": "invalid_password"
+  },
+  "fields": {
+    "account": "alice@example.com",
+    "tenant_id": "tenant_a",
+    "client_ip": "203.0.113.10"
+  }
+}
+```
+
+</details>
+
+## Merge Semantics in Logger Attributes
+
+Attribute constructors merge non-empty structured values:
+
+- `ResourceAttr`, `CorrelationAttr`, `EventAttr`, and `NodeAttr` overlay non-empty fields.
+- `TagsAttr` and `FieldsAttr` copy entries with non-empty keys.
+- `FieldAttr` adds one entry to `fields`.
+- `ErrorAttr` attaches the error field.
+
+Call-site attributes are applied after logger-level attributes and context correlation. Call-site values can override earlier structured values.
+
+## Related References
+
+- [Contract](contract.md)
+- [Runtime Boundary](runtime-boundary.md)
+- [Functions and API](functions.md)

--- a/docs/en-us/handbook/shared-packages/logging/runtime-boundary.md
+++ b/docs/en-us/handbook/shared-packages/logging/runtime-boundary.md
@@ -1,0 +1,129 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/en-us/handbook/shared-packages/logging/runtime-boundary.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Logging Runtime Boundary
+
+This page answers how `packages/shared/logging` touches zap, lumberjack, and OpenTelemetry SDKs without taking over runtime bootstrap.
+
+## Boundary Diagram
+
+```mermaid
+flowchart LR
+    cfg["logging.Config"] --> zap["NewZapCoreBase"]
+    cfg --> otel["NewOpenTelemetrySDKBase"]
+    zap --> logger["NewLogger"]
+    logger --> app["business code"]
+    otel --> runtime["runtime bootstrap"]
+    runtime --> globals["optional process globals"]
+    runtime --> exporters["optional exporters"]
+```
+
+The package builds reusable primitives. The runtime decides when and where to install or expose those primitives.
+
+## Zap Core Base
+
+`NewZapCoreBase` currently implements:
+
+- Dox `Level` to `zapcore.Level` mapping;
+- zap `AtomicLevel` creation;
+- symbolic encoder mapping;
+- zap `Config` mapping;
+- console core creation;
+- JSON file core creation;
+- lumberjack rotation for a single output path;
+- no-rotation file core through zap output paths;
+- zap options for development, caller, stacktrace, error output, and initial fields;
+- optional zap sampling;
+- `DisableErrorVerbose` behavior that keeps `error` as the basic string and suppresses `errorVerbose`.
+
+`ZapCoreBase.Close` releases opened sinks. Runtime bootstrap must call it during shutdown when it owns a base.
+
+## File Core Boundary
+
+| Rotation Driver | Current Behavior |
+| --- | --- |
+| `lumberjack` | Supported for file cores with exactly one output path. |
+| `none` | Supported through zap file output path behavior. |
+| `external` | Valid config value, but rejected by the current zap file sink. |
+| `logrotate` | Valid config value, but rejected by the current zap file sink. |
+
+> [!CAUTION]
+> Lumberjack assumes only one process writes to the configured file path on the same machine. Deployment policy must avoid multiple Dox processes sharing one rotating file path.
+
+## OpenTelemetry SDK Base
+
+`NewOpenTelemetrySDKBase` currently implements:
+
+- Dox `Resource` to OpenTelemetry resource attributes;
+- merge over `sdkresource.Default()`;
+- trace context and baggage propagator mapping;
+- trace sampler mapping for `always_on`, `always_off`, `traceidratio`, and `parentbased_traceidratio`;
+- optional tracer provider construction;
+- optional meter provider construction;
+- optional logger provider construction;
+- force flush and shutdown using `Shutdown.Timeout`.
+
+When root OpenTelemetry is disabled, the base still exposes a resource and a no-op propagator but does not build providers.
+
+## OpenTelemetry Boundary
+
+The SDK base does not call:
+
+- `otel.SetTracerProvider`;
+- `otel.SetMeterProvider`;
+- `otel.SetTextMapPropagator`;
+- any process-global log provider setter.
+
+It also does not create OTLP exporters. If `otel.exporter.otlp.enabled` is true, `NewOpenTelemetrySDKBase` returns a validation error for `otel.exporter.otlp.enabled`.
+
+## Runtime Bootstrap Responsibilities
+
+Runtime bootstrap owns:
+
+- translating runtime setting into `logging.Config` and `logging.Resource`;
+- rendering any output path templates;
+- choosing file locations and deployment sink policy;
+- constructing `ZapCoreBase`;
+- constructing the `Logger` facade;
+- constructing `OpenTelemetrySDKBase`;
+- optionally installing OpenTelemetry globals;
+- configuring exporters or collectors;
+- injecting correlation into HTTP, task, job, workflow, and plugin contexts;
+- calling `Sync`, `ForceFlush`, `Shutdown`, and `Close` at the right lifecycle points.
+
+## Current Gaps That Must Stay Visible
+
+| Gap | Why It Matters |
+| --- | --- |
+| Redaction is not applied | Sensitive values can still appear unless callers sanitize before logging. |
+| Buffering is not installed | `BufferingConfig` does not create a buffered writer yet. |
+| Dataset routing is not applied | All enabled cores receive records according to level; `event.dataset` does not select cores yet. |
+| Default file path template is not rendered | The default path is literal unless runtime code replaces placeholders. |
+| OTLP exporter is unsupported | Runtime/exporter integration must be implemented separately. |
+| No runtime bootstrap is included | Server, scheduler, collector, and compute must wire lifecycle behavior themselves. |
+
+## Related References
+
+- [Contract](contract.md)
+- [Model](model.md)
+- [Functions and API](functions.md)

--- a/docs/zh-cn/handbook/shared-packages/logging/README.md
+++ b/docs/zh-cn/handbook/shared-packages/logging/README.md
@@ -1,0 +1,127 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/zh-cn/handbook/shared-packages/logging/README.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Logging 包参考
+
+`packages/shared/logging` 定义 Dox 共享 logging model、configuration contract、logger facade、zap core helpers 和 OpenTelemetry SDK helpers。
+
+这份参考文档面向正式工程手册引用。它不是线性教程；每个页面都是自包含引用页，回答一种实现问题。
+
+> [!IMPORTANT]
+> Runtime packages 可以引用这个包，但 runtime bootstrap 仍然负责 logger construction、OpenTelemetry global installation、HTTP middleware wiring、scheduler/collector/compute integration，以及部署相关 output policy。
+
+## Reference Map
+
+| 页面 | 适合用来查询 |
+| --- | --- |
+| [契约](contract.md) | 包保证什么、不实现什么，以及 config validation/error semantics。 |
+| [模型](model.md) | Resource、correlation、event、node、tags、fields 在 log records 中如何成形。 |
+| [Runtime 边界](runtime-boundary.md) | Zap core base 和 OpenTelemetry SDK base 会构建什么，哪些 runtime responsibilities 仍在包外。 |
+| [函数与 API](functions.md) | 调用方可用的 exported types、constructors、helpers 和 constants。 |
+
+## 包定位
+
+```mermaid
+flowchart TD
+    runtime["runtime setting aggregate"] --> config["logging.Config"]
+    config --> zapbase["ZapCoreBase<br/>zap core helpers"]
+    config --> otelbase["OpenTelemetrySDKBase<br/>SDK provider helpers"]
+    zapbase --> facade["logging.Logger facade"]
+    otelbase --> bootstrap["runtime bootstrap"]
+    facade --> business["business code"]
+    bootstrap --> globals["optional runtime globals<br/>not installed by this package"]
+```
+
+Business code 应依赖 `logging.Logger` 和 `logging.Attr`。Runtime bootstrap code 可以使用 `ZapCoreBase` 和 `OpenTelemetrySDKBase`。
+
+## 当前能力矩阵
+
+| 区域 | 当前状态 |
+| --- | --- |
+| Config shape | 已实现 defaults、JSON/YAML/mapstructure tags 和 validation。 |
+| Logger facade | 已实现 Dox-owned `Logger` 和 `Attr` API，business-facing signatures 不暴露 zap types。 |
+| Context correlation | 已实现 context storage、overlay merge 和 log-call merge behavior。 |
+| Zap console core | 已实现。 |
+| Zap JSON file core | 已实现。 |
+| Lumberjack rotation | 已为 single-path file core 实现。 |
+| OpenTelemetry resource | 已实现，并 merge 到 SDK defaults 之上。 |
+| OpenTelemetry propagator | 已为 trace context 和 baggage 实现。 |
+| OpenTelemetry SDK providers | traces、metrics、logs 开启时已实现 provider construction。 |
+| OpenTelemetry global installation | 本包不实现。 |
+| OTLP exporter setup | 不实现；SDK base 会拒绝开启的 OTLP exporter。 |
+| Dataset routing | 已配置和验证，但尚未应用到 core routing。 |
+| Buffering | 已配置和验证，但尚未安装 buffered writer。 |
+| Redaction | 已配置和验证，但尚未执行 field/value redaction。 |
+| Default file path template rendering | 未实现；template 当前会作为 literal output path 传入。 |
+
+## 默认配置形状
+
+默认配置会创建一个 console core 和一个 JSONL file core：
+
+```yaml
+level: info
+cores:
+  - name: console
+    enabled: true
+    type: console
+    level: info
+    encoding: console
+    output_paths: ["stdout"]
+    datasets: ["*"]
+  - name: service-file
+    enabled: true
+    type: file
+    level: info
+    encoding: json
+    output_paths: ["logs/${service.namespace}-${service.name}.jsonl"]
+    datasets: ["*"]
+    rotation:
+      driver: lumberjack
+      enabled: true
+      max_size_mb: 100
+      max_backups: 10
+      max_age_days: 14
+      compress: true
+      local_time: true
+```
+
+> [!WARNING]
+> `logs/${service.namespace}-${service.name}.jsonl` 当前只是字符串默认值，不是已渲染模板。真正获得动态 service-specific path 前，runtime bootstrap 或后续 package change 必须负责渲染。
+
+## 正式文档引用方式
+
+系统工程手册应该链接到这份参考，而不是复制包行为。适合引用的目标包括：
+
+- `logging.Config` defaults 和 validation rules；
+- resource/correlation/event fields 的 log record model；
+- zap 和 OpenTelemetry runtime boundary；
+- explicit unsupported behavior matrix。
+
+Web、Scheduling、Collection、Computation 的手册应该单独记录自己的 bootstrap choices，例如 output paths、global provider installation、middleware correlation 和 deployment collectors。
+
+## 相关参考
+
+- [Shared config 包](../config/README.md)
+- [Shared setting 包](../setting/README.md)
+- Package source: `packages/shared/logging`
+- Current server consumer: `server/internal/setting`

--- a/docs/zh-cn/handbook/shared-packages/logging/contract.md
+++ b/docs/zh-cn/handbook/shared-packages/logging/contract.md
@@ -1,0 +1,157 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/zh-cn/handbook/shared-packages/logging/contract.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Logging 契约
+
+本页回答调用方可以从 `packages/shared/logging` 依赖什么，哪些行为目前只是配置形状，以及哪些 error 属于包契约。
+
+## Ownership Contract
+
+| 区域 | Package Owns | Runtime Owns |
+| --- | --- | --- |
+| Logging vocabulary | Resource、correlation、event、node、tags、fields model。 | Runtime-specific naming policy 和 business event taxonomy。 |
+| Business logging API | `Logger`、`Attr` 和 typed attribute constructors。 | 把 facade 传给 services 和 middleware。 |
+| zap mapping | Level、encoder、config、console core、JSON/file core、lumberjack helpers。 | Output paths、lifecycle、deployment topology 和 sink ownership。 |
+| OpenTelemetry SDK base | Resource mapping、propagator mapping、SDK provider construction、flush/shutdown helpers。 | Installing globals、exporter wiring 和 lifecycle integration。 |
+| Config validation | Defaults 和 package validation errors。 | Runtime-specific configuration restrictions 和 environment-specific policy。 |
+
+> [!NOTE]
+> 这个包是共享基础设施。它不会自己为任何进程启动 logging。
+
+## Config 契约
+
+`Config` 是 root shared logging configuration shape。
+
+| Group | 用途 |
+| --- | --- |
+| `Level` | Root Dox logging level。 |
+| `Development` | Root development-mode switch，会进入 zap defaults。 |
+| `Resource` | Logging-specific resource overrides，目前是 `service_version`。 |
+| `Zap` | zap-facing config shape 和 encoder symbols。 |
+| `Cores` | Console/file core declarations。 |
+| `Buffering` | Future buffered writer behavior。 |
+| `Shutdown` | Flush/shutdown timeout。 |
+| `Redaction` | Sensitive key replacement policy shape。 |
+| `OTel` | OpenTelemetry propagation、provider、exporter、batch settings。 |
+
+`Config.Default` 先填默认值，再进行 validation。`Config.Validate` 检查受支持 enum values、required paths、duplicate core names、positive durations and sizes、redaction key shape、OTLP protocol shape 和 batch constraints。
+
+## Default 契约
+
+| Field | Default |
+| --- | --- |
+| Root level | `info` |
+| zap encoding | `json` |
+| zap output paths | `stdout` |
+| zap error output paths | `stderr` |
+| encoder message key | `message` |
+| encoder level key | `severity_text` |
+| encoder time key | `timestamp` |
+| buffering | enabled, `262144` bytes, `1s` flush interval |
+| shutdown timeout | `5s` |
+| redaction | enabled, `[REDACTED]`, default sensitive keys |
+| OpenTelemetry | root/traces/metrics/logs enabled, trace context and baggage enabled |
+| OTLP exporter | 默认 disabled |
+
+显式 disabled 的 pointer toggles 在 defaults 后仍保持 disabled。
+
+## Validation Error 契约
+
+包暴露：
+
+- `FieldError`，包含 `Field` 和 `Reason`；
+- `ValidationError`，包含 `Fields []FieldError`；
+- 适合日志的紧凑 error string。
+
+调用方应检查 `ValidationError.Fields`，不要解析 error string。
+
+<details>
+<summary>Validation fields 示例</summary>
+
+```text
+level: level is not supported
+cores[1].name: core name must be unique
+redaction.keys[0]: redaction key must not be empty
+otel.traces.sampler.ratio: trace sampler ratio must be between 0 and 1
+```
+
+</details>
+
+## 已实现与仅配置契约
+
+| Setting | Validation | 当前 Runtime Effect |
+| --- | --- | --- |
+| `cores[].datasets` | 校验为 non-empty entries。 | 尚未用于 event dataset routing。 |
+| `buffering.*` | enabled 时校验。 | 尚未安装 buffered writer。 |
+| `redaction.*` | enabled 时校验。 | 尚未对 log field 或 value 执行 redaction。 |
+| `cores[].rotation.driver=external/logrotate` | 合法 enum value。 | 当前 zap file sink 会拒绝。 |
+| `otel.exporter.otlp.*` | Shape 会校验。 | Enabled OTLP exporter 会被 `NewOpenTelemetrySDKBase` 拒绝。 |
+| `zap.sampling.hook_metrics` | 配置形状的一部分。 | 尚未安装 sampling hook metrics。 |
+| `DefaultFilePathTemplate` | 作为默认字符串使用。 | Template variables 不会被渲染。 |
+
+> [!WARNING]
+> 仅配置契约应被视为 forward-compatible schema，而不是 active runtime behavior。
+
+## Logger 契约
+
+Business-facing code 使用 `Logger` 和 `Attr`。
+
+Facade 保证：
+
+- log level methods: `Debug`, `Info`, `Warn`, `Error`, `DPanic`, `Panic`, `Fatal`;
+- logger derivation: `Named`, `With`;
+- flush path: `Sync`;
+- Dox-owned attributes，用于 resource、correlation、event、node、tags、fields、single fields 和 errors；
+- 每次 write 时合并 context correlation。
+
+Facade 刻意不在 method signatures 中暴露 `zap.Logger` 或 `zap.Field`。
+
+## Context Correlation 契约
+
+Correlation helpers 提供简单 overlay semantics：
+
+- `ContextWithCorrelation` 存储 correlation value；nil context 会使用 `context.Background`。
+- `ContextWithMergedCorrelation` 把 non-empty overlay fields 合并进已有 context correlation。
+- `CorrelationFromContext` 对 nil 或缺失 context 返回 `(Correlation, false)`。
+- `MergeCorrelation` 保留 base fields，除非 overlay fields 非空。
+
+## 契约之外
+
+以下行为当前不属于包契约：
+
+- server/scheduler/collector/compute startup 时打开 runtime loggers；
+- HTTP middleware correlation；
+- task/job/plugin correlation injection；
+- OpenTelemetry global provider installation；
+- OTLP exporter construction；
+- collector deployment examples；
+- runtime-specific sink path rendering；
+- multi-process rotation coordination；
+- field-level redaction execution；
+- dataset-based core routing。
+
+## 相关参考
+
+- [模型](model.md)
+- [Runtime 边界](runtime-boundary.md)
+- [函数与 API](functions.md)

--- a/docs/zh-cn/handbook/shared-packages/logging/functions.md
+++ b/docs/zh-cn/handbook/shared-packages/logging/functions.md
@@ -1,0 +1,154 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/zh-cn/handbook/shared-packages/logging/functions.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Logging 函数与 API
+
+本页回答调用方可以使用哪些 exported logging APIs，以及每个 API 的用途。
+
+## Constants 和 Enums
+
+| API | 用途 |
+| --- | --- |
+| `DefaultFilePathTemplate` | 默认 JSONL file path string。当前不会由本包渲染。 |
+| `DefaultRedactionReplacement` | Redaction config 的默认 replacement string。 |
+| `Level` and level constants | Dox logging levels: debug, info, warn, error, dpanic, panic, fatal。 |
+| `Encoding` and encoding constants | 支持的 encodings: console and json。 |
+| `CoreType` and core constants | 支持的 core types: console and file。 |
+| `RotationDriver` and driver constants | Rotation strategy values: lumberjack, external, logrotate, none。 |
+| `OTLPProtocol` and protocol constants | OTLP protocol values: grpc and http。 |
+| `TraceSamplerType` and sampler constants | OpenTelemetry sampler shape values。 |
+
+每个 enum type 都有 `IsValid` method。
+
+## Config API
+
+| API | 用途 |
+| --- | --- |
+| `Config.Default() error` | 应用 shared logging defaults。 |
+| `Config.Validate() error` | 校验 shared logging configuration contract。 |
+| `DefaultRedactionKeys() []string` | 返回默认 sensitive key list。 |
+
+大多数 nested config structs 都有 `Default` methods，由 `Config.Default` 使用；调用方通常只需要调用 root config defaults。
+
+## Model API
+
+| Type | 用途 |
+| --- | --- |
+| `Resource` | Telemetry producer identity。 |
+| `Correlation` | Request/task/workflow/plugin correlation identity。 |
+| `Event` | Observability event classification。 |
+| `Node` | Service-internal component and operation。 |
+| `Tags` | Low-cardinality business labels。 |
+| `Fields` | Higher-cardinality event facts。 |
+
+`fields.go` 中的 field name constants 定义稳定 output keys。
+
+## Logger API
+
+| API | 用途 |
+| --- | --- |
+| `Logger` | Business-facing logging facade。 |
+| `Attr` | Opaque attribute application type。 |
+| `NewLogger(base, attrs...)` | 把 `ZapCoreBase` 包装成 Dox logger facade。 |
+| `ResourceAttr` | 添加 resource fields。 |
+| `CorrelationAttr` | 添加 correlation fields。 |
+| `EventAttr` | 添加 event fields。 |
+| `NodeAttr` | 添加 component and operation fields。 |
+| `TagsAttr` | 添加 tags object entries。 |
+| `FieldsAttr` | 添加 fields object entries。 |
+| `FieldAttr` | 添加一个 fields object entry。 |
+| `ErrorAttr` | 添加一个 error field。 |
+
+`NewLogger` 会拒绝 nil `ZapCoreBase`。Logger facade method signatures 不暴露 zap types。
+
+## Context API
+
+| API | 用途 |
+| --- | --- |
+| `ContextWithCorrelation(ctx, correlation)` | 在 context 上存储 correlation。 |
+| `ContextWithMergedCorrelation(ctx, correlation)` | 把 non-empty fields 合并进 context correlation。 |
+| `CorrelationFromContext(ctx)` | 取出 correlation 和 boolean。 |
+| `MergeCorrelation(base, overlay)` | 把 non-empty overlay fields 应用到 base。 |
+
+Helper functions 会安全处理 nil context。
+
+## Zap API
+
+| API | 用途 |
+| --- | --- |
+| `ZapCoreBase` | Runtime-owned zap primitives and close lifecycle。 |
+| `NewZapLevel(level)` | 把 Dox level 映射到 zapcore level。 |
+| `NewZapAtomicLevel(level)` | 创建 zap atomic level。 |
+| `NewZapEncoderConfig(config)` | 把 symbolic encoder config 映射到 zapcore encoder config。 |
+| `NewZapConfig(config)` | 把 Dox config 映射到 zap config。 |
+| `NewZapCoreBase(config)` | 构建 enabled zap cores 和 zap options。 |
+| `(*ZapCoreBase).Options()` | 返回复制后的 zap options。 |
+| `(*ZapCoreBase).Close()` | 关闭已打开 sinks，一次性执行。 |
+
+Runtime bootstrap 应拥有 `ZapCoreBase` lifecycle，不应把 zap primitives 暴露给 business code。
+
+## OpenTelemetry API
+
+| API | 用途 |
+| --- | --- |
+| `OpenTelemetrySDKBase` | Runtime-owned OpenTelemetry SDK primitives。 |
+| `NewOpenTelemetrySDKBase(config, resource)` | 构建 resource、propagator 和 enabled providers。 |
+| `NewOpenTelemetryResource(model, config)` | 把 Dox resource 映射到 SDK resource。 |
+| `NewOpenTelemetryPropagator(config)` | 构建 trace context/baggage propagator。 |
+| `NewOpenTelemetryTraceSampler(config)` | 构建 SDK trace sampler。 |
+| `(*OpenTelemetrySDKBase).ForceFlush(ctx)` | Flush enabled SDK providers。 |
+| `(*OpenTelemetrySDKBase).Shutdown(ctx)` | Shutdown enabled SDK providers。 |
+
+SDK base 返回 provider objects。它不安装 globals 或 exporters。
+
+## Runtime Integration Sketch
+
+```go
+cfg := logging.Config{}
+if err := cfg.Default(); err != nil {
+	return err
+}
+if err := cfg.Validate(); err != nil {
+	return err
+}
+
+zapBase, err := logging.NewZapCoreBase(cfg)
+if err != nil {
+	return err
+}
+defer zapBase.Close()
+
+logger, err := logging.NewLogger(zapBase, logging.ResourceAttr(resource))
+if err != nil {
+	return err
+}
+defer logger.Sync()
+```
+
+这个 sketch 省略 runtime policy，例如 path rendering、global OpenTelemetry installation 和 shutdown orchestration。
+
+## 相关参考
+
+- [契约](contract.md)
+- [模型](model.md)
+- [Runtime 边界](runtime-boundary.md)

--- a/docs/zh-cn/handbook/shared-packages/logging/model.md
+++ b/docs/zh-cn/handbook/shared-packages/logging/model.md
@@ -1,0 +1,194 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/zh-cn/handbook/shared-packages/logging/model.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Logging 模型
+
+本页回答 Dox log records 应如何描述 producer、execution chain、observed event、internal node、tags 和 detailed fields。
+
+## 模型图
+
+```mermaid
+classDiagram
+    class Resource {
+        service namespace/name/instance/version
+        deployment environment
+        cloud and k8s placement
+        Dox organization/application/runtime
+    }
+    class Correlation {
+        trace/span flags
+        request/correlation IDs
+        job/task/workflow IDs
+        plugin IDs
+    }
+    class Event {
+        name
+        dataset
+        category
+        type
+        action
+        outcome
+    }
+    class Node {
+        component
+        operation
+    }
+    class Tags
+    class Fields
+    Resource --> Event : produced by
+    Correlation --> Event : connects
+    Node --> Event : happened in
+    Tags --> Event : low-cardinality labels
+    Fields --> Event : event facts
+```
+
+## Resource
+
+Resource fields 回答谁产生了 telemetry。
+
+| Field Constant | JSON Field | 含义 |
+| --- | --- | --- |
+| `FieldServiceNamespace` | `service.namespace` | Service namespace，通常是 `dox`。 |
+| `FieldServiceName` | `service.name` | Service capability name，不一定等于 runtime。 |
+| `FieldServiceInstanceID` | `service.instance.id` | Process、pod、node 或 instance identity。 |
+| `FieldServiceVersion` | `service.version` | Deployed service version。 |
+| `FieldDeploymentEnvironmentName` | `deployment.environment.name` | Deployment env，例如 `prod`。 |
+| `FieldCloudRegion` | `cloud.region` | Cloud region。 |
+| `FieldCloudAvailabilityZone` | `cloud.availability_zone` | Cloud availability zone。 |
+| `FieldK8sClusterName` | `k8s.cluster.name` | Kubernetes cluster。 |
+| `FieldK8sNamespaceName` | `k8s.namespace.name` | Kubernetes namespace。 |
+| `FieldDoxOrganization` | `dox.organization` | Dox owner organization。 |
+| `FieldDoxApplication` | `dox.application` | Dox application family。 |
+| `FieldDoxRuntime` | `dox.runtime` | Dox runtime: `server`, `scheduler`, `collector`, `compute`。 |
+
+> [!TIP]
+> `service.name` 标识 service capability。`dox.runtime` 标识 runtime process family。一个 `server` runtime 可以承载 `iam` service。
+
+## Correlation
+
+Correlation fields 连接 request、job、task、workflow、plugin run 或 cross-runtime chain。
+
+| Field Constant | JSON Field |
+| --- | --- |
+| `FieldTraceID` | `trace_id` |
+| `FieldSpanID` | `span_id` |
+| `FieldTraceFlags` | `trace_flags` |
+| `FieldRequestID` | `request_id` |
+| `FieldCorrelationID` | `correlation_id` |
+| `FieldJobID` | `job_id` |
+| `FieldTaskID` | `task_id` |
+| `FieldWorkflowID` | `workflow_id` |
+| `FieldPluginID` | `plugin_id` |
+| `FieldPluginRunID` | `plugin_run_id` |
+
+`trace_id`、`span_id`、`trace_flags` 与 OpenTelemetry 对齐。`correlation_id` 由 Dox 拥有，应跨 request、task、event、plugin boundaries 保留下来。
+
+## Event
+
+Event fields 描述 log record 观察到什么。
+
+| Field Constant | JSON Field | 示例 |
+| --- | --- | --- |
+| `FieldEventName` | `event.name` | `iam.login.rejected` |
+| `FieldEventDataset` | `event.dataset` | `dox.iam.security` |
+| `FieldEventCategory` | `event.category` | `authentication` |
+| `FieldEventType` | `event.type` | `denied` |
+| `FieldEventAction` | `event.action` | `login` |
+| `FieldEventOutcome` | `event.outcome` | `failure` |
+
+这里没有 first-class `channel` field。Dataset、category、type、action 和 outcome 承担 event classification。
+
+## Node
+
+Node fields 描述 event 发生在 service 内部哪里。
+
+| Field Constant | JSON Field | 含义 |
+| --- | --- | --- |
+| `FieldComponent` | `component` | Internal component，例如 `auth_service`。 |
+| `FieldOperation` | `operation` | Operation，例如 `verify_credential`。 |
+
+## Tags 和 Fields
+
+`Tags` 是当前 node 声明的 low-cardinality business labels。`Fields` 是 event facts 和 higher-cardinality details。
+
+| 使用 `tags` 表示 | 使用 `fields` 表示 |
+| --- | --- |
+| `risk_level` | `account` |
+| `login_method` | `tenant_id` |
+| `credential_type` | `client_ip` |
+| `reject_reason` | `failed_attempts` |
+| `queue` | raw IDs and measured facts |
+
+不要把 resource fields、correlation IDs 或 verbose error text 放进 `tags`。
+
+<details>
+<summary>示例：IAM login rejected record</summary>
+
+```json
+{
+  "service.namespace": "dox",
+  "service.name": "iam",
+  "dox.runtime": "server",
+  "deployment.environment.name": "prod",
+  "trace_id": "trace_001",
+  "request_id": "req_001",
+  "correlation_id": "corr_001",
+  "event.name": "iam.login.rejected",
+  "event.dataset": "dox.iam.security",
+  "event.category": "authentication",
+  "event.type": "denied",
+  "event.action": "login",
+  "event.outcome": "failure",
+  "component": "auth_service",
+  "operation": "verify_credential",
+  "tags": {
+    "risk_level": "medium",
+    "login_method": "password",
+    "reject_reason": "invalid_password"
+  },
+  "fields": {
+    "account": "alice@example.com",
+    "tenant_id": "tenant_a",
+    "client_ip": "203.0.113.10"
+  }
+}
+```
+
+</details>
+
+## Logger Attributes 的 Merge Semantics
+
+Attribute constructors 会合并 non-empty structured values：
+
+- `ResourceAttr`、`CorrelationAttr`、`EventAttr`、`NodeAttr` overlay non-empty fields。
+- `TagsAttr` 和 `FieldsAttr` copy non-empty keys 的 entries。
+- `FieldAttr` 向 `fields` 增加一个 entry。
+- `ErrorAttr` attach error field。
+
+Call-site attributes 会在 logger-level attributes 和 context correlation 之后应用。Call-site values 可以覆盖之前的 structured values。
+
+## 相关参考
+
+- [契约](contract.md)
+- [Runtime 边界](runtime-boundary.md)
+- [函数与 API](functions.md)

--- a/docs/zh-cn/handbook/shared-packages/logging/runtime-boundary.md
+++ b/docs/zh-cn/handbook/shared-packages/logging/runtime-boundary.md
@@ -1,0 +1,129 @@
+<!--
+  dox
+  Copyright (C) 2026  OpenDox
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+  @File    : docs/zh-cn/handbook/shared-packages/logging/runtime-boundary.md
+  @Author  : Frost Leo <frostleo.dev@gmail.com>
+  @Created : 2026-04-27
+  @Modified: 2026-04-27
+-->
+
+# Shared Logging Runtime 边界
+
+本页回答 `packages/shared/logging` 如何接触 zap、lumberjack 和 OpenTelemetry SDK，同时不接管 runtime bootstrap。
+
+## Boundary Diagram
+
+```mermaid
+flowchart LR
+    cfg["logging.Config"] --> zap["NewZapCoreBase"]
+    cfg --> otel["NewOpenTelemetrySDKBase"]
+    zap --> logger["NewLogger"]
+    logger --> app["business code"]
+    otel --> runtime["runtime bootstrap"]
+    runtime --> globals["optional process globals"]
+    runtime --> exporters["optional exporters"]
+```
+
+这个包构建可复用 primitives。Runtime 决定何时、何处安装或暴露这些 primitives。
+
+## Zap Core Base
+
+`NewZapCoreBase` 当前实现：
+
+- Dox `Level` 到 `zapcore.Level` 的 mapping；
+- zap `AtomicLevel` creation；
+- symbolic encoder mapping；
+- zap `Config` mapping；
+- console core creation；
+- JSON file core creation；
+- single output path 的 lumberjack rotation；
+- 通过 zap output paths 实现 no-rotation file core；
+- development、caller、stacktrace、error output、initial fields 等 zap options；
+- optional zap sampling；
+- `DisableErrorVerbose` behavior，让 `error` 保持 basic string 并 suppress `errorVerbose`。
+
+`ZapCoreBase.Close` 释放已打开 sinks。Runtime bootstrap 拥有 base 时，必须在 shutdown 时调用。
+
+## File Core 边界
+
+| Rotation Driver | 当前行为 |
+| --- | --- |
+| `lumberjack` | 支持 exactly one output path 的 file core。 |
+| `none` | 通过 zap file output path behavior 支持。 |
+| `external` | 合法 config value，但当前 zap file sink 会拒绝。 |
+| `logrotate` | 合法 config value，但当前 zap file sink 会拒绝。 |
+
+> [!CAUTION]
+> Lumberjack 假设同一台机器上只有一个 process 写入配置的 file path。Deployment policy 必须避免多个 Dox processes 共享同一个 rotating file path。
+
+## OpenTelemetry SDK Base
+
+`NewOpenTelemetrySDKBase` 当前实现：
+
+- Dox `Resource` 到 OpenTelemetry resource attributes 的 mapping；
+- merge 到 `sdkresource.Default()` 之上；
+- trace context 和 baggage propagator mapping；
+- `always_on`、`always_off`、`traceidratio`、`parentbased_traceidratio` trace sampler mapping；
+- optional tracer provider construction；
+- optional meter provider construction；
+- optional logger provider construction；
+- 使用 `Shutdown.Timeout` 的 force flush 和 shutdown。
+
+Root OpenTelemetry disabled 时，base 仍暴露 resource 和 no-op propagator，但不会构建 providers。
+
+## OpenTelemetry 边界
+
+SDK base 不调用：
+
+- `otel.SetTracerProvider`;
+- `otel.SetMeterProvider`;
+- `otel.SetTextMapPropagator`;
+- 任何 process-global log provider setter。
+
+它也不创建 OTLP exporters。如果 `otel.exporter.otlp.enabled` 为 true，`NewOpenTelemetrySDKBase` 会为 `otel.exporter.otlp.enabled` 返回 validation error。
+
+## Runtime Bootstrap 责任
+
+Runtime bootstrap 拥有：
+
+- 把 runtime setting 转换成 `logging.Config` 和 `logging.Resource`；
+- 渲染任何 output path templates；
+- 选择 file locations 和 deployment sink policy；
+- 构建 `ZapCoreBase`；
+- 构建 `Logger` facade；
+- 构建 `OpenTelemetrySDKBase`；
+- 可选地安装 OpenTelemetry globals；
+- 配置 exporters 或 collectors；
+- 向 HTTP、task、job、workflow、plugin contexts 注入 correlation；
+- 在正确生命周期点调用 `Sync`、`ForceFlush`、`Shutdown`、`Close`。
+
+## 必须保持可见的当前缺口
+
+| Gap | 为什么重要 |
+| --- | --- |
+| Redaction is not applied | 除非调用方先 sanitize，否则敏感值仍可能进入日志。 |
+| Buffering is not installed | `BufferingConfig` 目前不会创建 buffered writer。 |
+| Dataset routing is not applied | 所有 enabled cores 按 level 接收 records；`event.dataset` 目前不会选择 cores。 |
+| Default file path template is not rendered | 除非 runtime code 替换 placeholders，否则默认 path 是 literal string。 |
+| OTLP exporter is unsupported | Runtime/exporter integration 必须单独实现。 |
+| No runtime bootstrap is included | Server、scheduler、collector、compute 必须自己 wire lifecycle behavior。 |
+
+## 相关参考
+
+- [契约](contract.md)
+- [模型](model.md)
+- [函数与 API](functions.md)


### PR DESCRIPTION
## Description

Adds a bilingual reference-style engineering handbook for the shared logging package. The docs establish `packages/shared/logging` as the formal reference for Dox logging config, the Dox-owned logger facade, log record model fields, zap core helpers, and OpenTelemetry SDK boundaries.

This PR intentionally changes documentation only. It avoids linear handbook navigation and instead structures the package docs as a reference hub plus self-contained pages that system engineering manuals can link to directly.

## Related Links

- Closes #40
- Refs #38
- Refs #39

## Scope

- [ ] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [x] Security
- [x] Backend

## Implementation Notes

- Adds English reference pages under `docs/en-us/handbook/shared-packages/logging/`.
- Adds Chinese reference pages under `docs/zh-cn/handbook/shared-packages/logging/`.
- Documents logging config contracts, logger facade behavior, model fields, context correlation, zap core boundaries, and OpenTelemetry SDK boundaries.
- Explicitly calls out contract-only or unsupported behavior: redaction execution, buffering, dataset routing, default path template rendering, OTLP exporter setup, and runtime bootstrap.
- Uses a reference map, implementation status tables, Mermaid diagrams, callouts, and details examples without Previous/Next navigation.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands run:

```sh
git diff --check
git diff --cached --check
git diff origin/develop...HEAD --check
```

Not run:

```sh
go test ./packages/shared/logging
```

The current environment does not have a `go` binary on `PATH`, so Go package tests could not be executed locally for this docs-only PR.

## Risks

The docs deliberately describe several config fields as current schema without active runtime behavior. This should reduce integration confusion, but future runtime integration issues must update these pages when redaction, buffering, dataset routing, path rendering, OTLP exporters, or bootstrap wiring become implemented.
