### PR TITLE
gh-46 [feat]: Assemble validated server settings

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -18,18 +18,18 @@
   @File    : server/README.md
   @Author  : Frost Leo <frostleo.dev@gmail.com>
   @Created : 2026-04-24
-  @Modified: 2026-04-26
+  @Modified: 2026-04-28
 -->
 
 # Dox Server
 
 `server` is the Web backend runtime for Dox.
 
-The current module contains the CLI entrypoint, shared version command, bootstrap configuration snapshot loading, and the initial server-owned identity setting aggregate. HTTP server startup, database access, logging, security, and EDA integration are intentionally out of scope for this milestone.
+The current module contains the CLI entrypoint, shared version command, bootstrap configuration snapshot loading, and server-owned setting assembly for identity and logging. HTTP server startup, database access, security, and EDA integration are intentionally out of scope for this milestone.
 
 ## Configuration Bootstrap
 
-`server/internal/bootstrap` can load a startup configuration snapshot through `packages/shared/config`.
+`server/internal/bootstrap` can load a startup configuration snapshot through `packages/shared/config` and assemble it into a typed `server/internal/setting.Setting`.
 
 The current bootstrap convention is:
 
@@ -38,7 +38,9 @@ The current bootstrap convention is:
 - `configs/local.<format>` as an optional local override;
 - `DOX_SERVER_` environment variables as optional final overrides.
 
-The bootstrap snapshot currently uses `map[string]any`. Concrete server setting groups belong under `server/internal/setting`, where each configuration group owns its own file. The first group is identity; concrete HTTP, database, cache, logger, security, and IAM setting structs remain out of scope until those runtime resources are introduced.
+Raw bootstrap snapshots use `map[string]any` and allow unknown keys so operators can inspect loaded values before typed assembly. Typed server setting assembly rejects unknown keys, applies defaults, and validates group semantics before runtime resources are constructed.
+
+Concrete server setting groups belong under `server/internal/setting`, where each configuration group owns its own file. Current groups cover identity and logging. Concrete HTTP, database, cache, security, and IAM setting structs remain out of scope until those runtime resources are introduced.
 
 ## Usage
 

--- a/server/internal/bootstrap/setting.go
+++ b/server/internal/bootstrap/setting.go
@@ -1,0 +1,87 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : setting.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-28
+ * @Modified: 2026-04-28
+ */
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+
+	sharedconfig "github.com/opendox/dox/packages/shared/config"
+	serversetting "github.com/opendox/dox/server/internal/setting"
+)
+
+// SettingSnapshot captures typed, defaulted, and validated server settings.
+type SettingSnapshot struct {
+	Runtime     string
+	Env         string
+	Setting     serversetting.Setting
+	SourceNames []string
+	Fingerprint string
+	Diagnostics sharedconfig.Diagnostics
+}
+
+// LoadSetting loads server configuration sources and assembles typed settings.
+func LoadSetting(ctx context.Context, options ConfigOptions) (*SettingSnapshot, error) {
+	configSnapshot, err := LoadConfig(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	return AssembleSetting(ctx, configSnapshot)
+}
+
+// AssembleSetting decodes, defaults, and validates settings from a config snapshot.
+func AssembleSetting(ctx context.Context, snapshot *ConfigSnapshot) (*SettingSnapshot, error) {
+	if snapshot == nil {
+		return nil, sharedconfig.ContractError("snapshot", "config snapshot must not be nil")
+	}
+
+	setting := serversetting.Setting{}
+	if err := sharedconfig.DecodeValues(ctx, snapshot.Values, &setting, sharedconfig.Options{
+		UnknownKeyPolicy: sharedconfig.UnknownKeyPolicyReject,
+	}); err != nil {
+		return nil, err
+	}
+	if err := setting.DefaultWithOptions(serversetting.DefaultOptions{Env: snapshot.Env}); err != nil {
+		return nil, fmt.Errorf("server setting default failed: %w", err)
+	}
+	if err := setting.Validate(); err != nil {
+		return nil, fmt.Errorf("server setting validation failed: %w", err)
+	}
+
+	return &SettingSnapshot{
+		Runtime:     snapshot.Runtime,
+		Env:         snapshot.Env,
+		Setting:     setting,
+		SourceNames: append([]string(nil), snapshot.SourceNames...),
+		Fingerprint: snapshot.Fingerprint,
+		Diagnostics: cloneConfigDiagnostics(snapshot.Diagnostics),
+	}, nil
+}
+
+func cloneConfigDiagnostics(input sharedconfig.Diagnostics) sharedconfig.Diagnostics {
+	return sharedconfig.Diagnostics{
+		Sources:   append([]sharedconfig.SourceDiagnostic(nil), input.Sources...),
+		Overrides: append([]sharedconfig.MergeOverride(nil), input.Overrides...),
+	}
+}

--- a/server/internal/bootstrap/setting_test.go
+++ b/server/internal/bootstrap/setting_test.go
@@ -1,0 +1,161 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : setting_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-28
+ * @Modified: 2026-04-28
+ */
+
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sharedconfig "github.com/opendox/dox/packages/shared/config"
+	sharedlogging "github.com/opendox/dox/packages/shared/logging"
+	sharedsetting "github.com/opendox/dox/packages/shared/setting"
+	serversetting "github.com/opendox/dox/server/internal/setting"
+)
+
+func TestLoadSettingBuildsValidatedSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	writeBootstrapFixture(t, filepath.Join(dir, "base.yaml"), `
+identity:
+  service:
+    name: api
+logging:
+  level: debug
+`)
+
+	snapshot, err := LoadSetting(context.Background(), ConfigOptions{
+		ConfigDir: dir,
+		Env:       "prod",
+		Format:    "yaml",
+		EnvPrefix: "DOX_BOOTSTRAP_TEST_SETTING_SUCCESS_",
+	})
+	if err != nil {
+		t.Fatalf("load setting snapshot: %v", err)
+	}
+
+	if snapshot.Runtime != configRuntime || snapshot.Env != "prod" {
+		t.Fatalf("unexpected setting snapshot identity: %+v", snapshot)
+	}
+	if !strings.HasPrefix(snapshot.Fingerprint, "sha256:") {
+		t.Fatalf("expected sha256 fingerprint, got %q", snapshot.Fingerprint)
+	}
+	if len(snapshot.SourceNames) != 4 {
+		t.Fatalf("expected source names to be preserved, got %+v", snapshot.SourceNames)
+	}
+	if len(snapshot.Diagnostics.Sources) != 4 {
+		t.Fatalf("expected diagnostics to be preserved, got %+v", snapshot.Diagnostics)
+	}
+	if snapshot.Setting.Identity.System.Runtime != serversetting.ServerRuntime {
+		t.Fatalf("expected server runtime default, got %q", snapshot.Setting.Identity.System.Runtime)
+	}
+	if snapshot.Setting.Identity.Service.Name != "api" {
+		t.Fatalf("expected decoded service name, got %q", snapshot.Setting.Identity.Service.Name)
+	}
+	if snapshot.Setting.Identity.Deployment.Env != sharedsetting.EnvProd {
+		t.Fatalf("expected deployment env from config options, got %q", snapshot.Setting.Identity.Deployment.Env)
+	}
+	if snapshot.Setting.Logging.Level != sharedlogging.LevelDebug {
+		t.Fatalf("expected decoded logging level debug, got %q", snapshot.Setting.Logging.Level)
+	}
+	if len(snapshot.Setting.Logging.Cores) == 0 {
+		t.Fatal("expected logging defaults to be applied")
+	}
+}
+
+func TestLoadConfigAllowsUnknownRawKeysAndLoadSettingRejectsThem(t *testing.T) {
+	dir := t.TempDir()
+	writeBootstrapFixture(t, filepath.Join(dir, "base.yaml"), `
+identity: {}
+unexpected_group:
+  enabled: true
+`)
+
+	rawSnapshot, err := LoadConfig(context.Background(), ConfigOptions{
+		ConfigDir: dir,
+		Env:       "dev",
+		Format:    "yaml",
+		EnvPrefix: "DOX_BOOTSTRAP_TEST_SETTING_UNKNOWN_RAW_",
+	})
+	if err != nil {
+		t.Fatalf("load raw config snapshot: %v", err)
+	}
+	if _, exists := rawSnapshot.Values["unexpected_group"]; !exists {
+		t.Fatalf("expected raw snapshot to keep unknown key, got %+v", rawSnapshot.Values)
+	}
+
+	_, err = LoadSetting(context.Background(), ConfigOptions{
+		ConfigDir: dir,
+		Env:       "dev",
+		Format:    "yaml",
+		EnvPrefix: "DOX_BOOTSTRAP_TEST_SETTING_UNKNOWN_TYPED_",
+	})
+	if !sharedconfig.IsKind(err, sharedconfig.ErrorKindDecode) {
+		t.Fatalf("expected typed setting decode error for unknown key, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "unexpected_group") {
+		t.Fatalf("expected unknown key to be identified, got %v", err)
+	}
+}
+
+func TestLoadSettingReturnsValidationErrorForInvalidSetting(t *testing.T) {
+	dir := t.TempDir()
+	writeBootstrapFixture(t, filepath.Join(dir, "base.yaml"), `
+identity:
+  system:
+    runtime: scheduler
+`)
+
+	_, err := LoadSetting(context.Background(), ConfigOptions{
+		ConfigDir: dir,
+		Env:       "dev",
+		Format:    "yaml",
+		EnvPrefix: "DOX_BOOTSTRAP_TEST_SETTING_INVALID_",
+	})
+	if !errors.Is(err, serversetting.ErrInvalidServerRuntime) {
+		t.Fatalf("expected invalid server runtime validation error, got %v", err)
+	}
+}
+
+func TestLoadSettingPropagatesSourceError(t *testing.T) {
+	_, err := LoadSetting(context.Background(), ConfigOptions{
+		ConfigDir: t.TempDir(),
+		Env:       "dev",
+		Format:    "yaml",
+		EnvPrefix: "DOX_BOOTSTRAP_TEST_SETTING_MISSING_BASE_",
+	})
+
+	if !sharedconfig.IsKind(err, sharedconfig.ErrorKindSource) {
+		t.Fatalf("expected source error, got %v", err)
+	}
+}
+
+func TestAssembleSettingRejectsNilSnapshot(t *testing.T) {
+	_, err := AssembleSetting(context.Background(), nil)
+
+	if !sharedconfig.IsKind(err, sharedconfig.ErrorKindContract) {
+		t.Fatalf("expected contract error, got %v", err)
+	}
+}

--- a/server/internal/setting/README.md
+++ b/server/internal/setting/README.md
@@ -18,7 +18,7 @@
   @File    : server/internal/setting/README.md
   @Author  : Frost Leo <frostleo.dev@gmail.com>
   @Created : 2026-04-26
-  @Modified: 2026-04-26
+  @Modified: 2026-04-28
 -->
 
 # Server Setting
@@ -29,13 +29,21 @@ Shared packages provide reusable configuration fragments. This package decides h
 
 ## Boundaries
 
-- `server/internal/bootstrap` loads source snapshots from files and environment variables.
+- `server/internal/bootstrap` loads source snapshots from files and environment variables, then assembles typed server settings.
 - `packages/shared/config` provides source loading, merging, and decoding primitives.
 - `packages/shared/setting` defines reusable setting fragments.
 - `packages/shared/logging` defines the shared logging model and runtime helper configuration.
 - `server/internal/setting` defines the server runtime aggregate and group-level semantics.
 
-Bootstrap should not own concrete HTTP, database, identity, logging, or security setting structs. It should continue to provide loaded values and diagnostics.
+Bootstrap should not own concrete HTTP, database, identity, logging, or security setting structs. It coordinates source loading, decode, defaulting, validation, and diagnostics preservation, while this package owns the setting groups and their semantics.
+
+The expected assembly order is:
+
+1. `server/internal/bootstrap` builds config sources from startup options.
+2. `packages/shared/config` loads and merges raw values into a `map[string]any` snapshot.
+3. `server/internal/bootstrap` decodes the snapshot into `Setting` with unknown keys rejected.
+4. `server/internal/setting` applies defaults and validates group semantics.
+5. Later runtime bootstrap code receives validated narrow setting groups and constructs resources.
 
 ## File Convention
 


### PR DESCRIPTION
## Description

Add the bootstrap-owned server setting assembly path for loaded config snapshots.

This PR keeps `server/internal/bootstrap` as the composition layer: it loads raw config values through `packages/shared/config`, decodes them into `server/internal/setting.Setting`, applies server defaults, validates group semantics, and preserves config metadata for later runtime bootstrap work.

## Related Links

- Closes #46
- Refs #24
- Refs #36

## Scope

- [ ] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [ ] Security

## Implementation Notes

- Added `LoadSetting` and `AssembleSetting` under `server/internal/bootstrap`.
- Raw config snapshots still target `map[string]any` with unknown keys allowed.
- Typed setting assembly rejects unknown keys, then applies defaults and validation.
- `SettingSnapshot` preserves runtime, env, source names, fingerprint, and diagnostics from the config snapshot.
- Runtime resource construction remains out of scope.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands:

```bash
go test -count=1 ./packages/shared/... ./server/...
```

## Risks

- No runtime constructors are added in this PR; later HTTP, database, Redis, RabbitMQ, and logging runtime work still needs separate issues.
- `SettingSnapshot` intentionally carries config metadata copied from `ConfigSnapshot`; it does not mean those fields are decoded from the setting schema.
