### PR TITLE
gh-48 [feat]: Add setting default validation contracts

### DIFF
--- a/server/internal/setting/README.md
+++ b/server/internal/setting/README.md
@@ -50,6 +50,8 @@ The expected assembly order is:
 Use one file per configuration group:
 
 - `setting.go` defines the root `Setting` aggregate.
+- `default.go` defines the defaulting contract shared by setting groups.
+- `validate.go` defines the validation contract shared by setting groups.
 - `identity.go` defines the identity group.
 - `logging.go` defines the server logging configuration group backed by shared logging config.
 - Future `database.go`, `http.go`, `security.go`, and similar files should define their own focused groups.
@@ -65,6 +67,30 @@ type Setting struct {
 ```
 
 Callers should pass narrow group settings to subsystems instead of passing the full root setting everywhere.
+
+## Defaults And Validation
+
+Setting groups that can fill stable defaults should implement:
+
+```go
+type Defaultable interface {
+    Default() error
+}
+```
+
+Setting groups that can validate their final values should implement:
+
+```go
+type Validatable interface {
+    Validate() error
+}
+```
+
+`DefaultGroups` applies defaults in order and stops on the first error. Use explicit root-level calls when a group needs bootstrap-derived seed values, such as identity using the bootstrap env.
+
+`ValidateGroups` validates groups and joins reported errors so startup can report every invalid group found in one pass.
+
+Future HTTP, database, Redis, RabbitMQ, security, plugin, and similar setting groups should plug into these default and validation contracts before runtime bootstrap consumes them. The contracts do not define those concrete groups, construct clients, open network listeners, resolve secrets, or start runtime resources.
 
 ## Identity
 

--- a/server/internal/setting/default.go
+++ b/server/internal/setting/default.go
@@ -1,0 +1,65 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : default.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-28
+ * @Modified: 2026-04-28
+ */
+
+package setting
+
+import (
+	"errors"
+	"reflect"
+)
+
+var (
+	// ErrNilDefaultable reports a nil setting group in a defaulting call.
+	ErrNilDefaultable = errors.New("server setting: defaultable group must not be nil")
+)
+
+// Defaultable is implemented by setting groups that can fill stable defaults.
+type Defaultable interface {
+	Default() error
+}
+
+// DefaultGroups applies defaults in order and stops on the first failure.
+func DefaultGroups(groups ...Defaultable) error {
+	for _, group := range groups {
+		if isNilInterface(group) {
+			return ErrNilDefaultable
+		}
+		if err := group.Default(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/server/internal/setting/default_test.go
+++ b/server/internal/setting/default_test.go
@@ -1,0 +1,82 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : default_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-28
+ * @Modified: 2026-04-28
+ */
+
+package setting
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestDefaultGroupsAppliesDefaultsInOrder(t *testing.T) {
+	var calls []string
+	first := defaultTestGroup{name: "first", calls: &calls}
+	second := defaultTestGroup{name: "second", calls: &calls}
+
+	if err := DefaultGroups(&first, &second); err != nil {
+		t.Fatalf("default groups: %v", err)
+	}
+	if !reflect.DeepEqual(calls, []string{"first", "second"}) {
+		t.Fatalf("unexpected default order: %+v", calls)
+	}
+}
+
+func TestDefaultGroupsStopsOnFirstFailure(t *testing.T) {
+	expected := errors.New("default failed")
+	var calls []string
+	first := defaultTestGroup{name: "first", calls: &calls}
+	second := defaultTestGroup{name: "second", calls: &calls, err: expected}
+	third := defaultTestGroup{name: "third", calls: &calls}
+
+	if err := DefaultGroups(&first, &second, &third); !errors.Is(err, expected) {
+		t.Fatalf("expected default failure, got %v", err)
+	}
+	if !reflect.DeepEqual(calls, []string{"first", "second"}) {
+		t.Fatalf("expected defaulting to stop on second group, got %+v", calls)
+	}
+}
+
+func TestDefaultGroupsRejectsNilGroup(t *testing.T) {
+	if err := DefaultGroups(nil); !errors.Is(err, ErrNilDefaultable) {
+		t.Fatalf("expected nil defaultable error, got %v", err)
+	}
+
+	var typedNil *defaultTestGroup
+	if err := DefaultGroups(typedNil); !errors.Is(err, ErrNilDefaultable) {
+		t.Fatalf("expected typed nil defaultable error, got %v", err)
+	}
+}
+
+type defaultTestGroup struct {
+	name  string
+	calls *[]string
+	err   error
+}
+
+func (g *defaultTestGroup) Default() error {
+	if g.calls != nil {
+		*g.calls = append(*g.calls, g.name)
+	}
+	return g.err
+}

--- a/server/internal/setting/setting.go
+++ b/server/internal/setting/setting.go
@@ -18,7 +18,7 @@
  * @File    : setting.go
  * @Author  : Frost Leo <frostleo.dev@gmail.com>
  * @Created : 2026-04-26
- * @Modified: 2026-04-26
+ * @Modified: 2026-04-28
  */
 
 package setting
@@ -51,7 +51,7 @@ func (s *Setting) DefaultWithOptions(options DefaultOptions) error {
 	}); err != nil {
 		return err
 	}
-	if err := s.Logging.Default(); err != nil {
+	if err := DefaultGroups(&s.Logging); err != nil {
 		return err
 	}
 	return nil
@@ -59,8 +59,8 @@ func (s *Setting) DefaultWithOptions(options DefaultOptions) error {
 
 // Validate verifies the concrete server configuration aggregate.
 func (s Setting) Validate() error {
-	return errors.Join(
-		s.Identity.Validate(),
-		s.Logging.Validate(),
+	return ValidateGroups(
+		s.Identity,
+		s.Logging,
 	)
 }

--- a/server/internal/setting/validate.go
+++ b/server/internal/setting/validate.go
@@ -1,0 +1,49 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : validate.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-28
+ * @Modified: 2026-04-28
+ */
+
+package setting
+
+import "errors"
+
+var (
+	// ErrNilValidatable reports a nil setting group in a validation call.
+	ErrNilValidatable = errors.New("server setting: validatable group must not be nil")
+)
+
+// Validatable is implemented by setting groups that can validate their values.
+type Validatable interface {
+	Validate() error
+}
+
+// ValidateGroups validates groups and joins all reported failures.
+func ValidateGroups(groups ...Validatable) error {
+	errs := make([]error, 0, len(groups))
+	for _, group := range groups {
+		if isNilInterface(group) {
+			errs = append(errs, ErrNilValidatable)
+			continue
+		}
+		errs = append(errs, group.Validate())
+	}
+	return errors.Join(errs...)
+}

--- a/server/internal/setting/validate_test.go
+++ b/server/internal/setting/validate_test.go
@@ -1,0 +1,60 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : validate_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-04-28
+ * @Modified: 2026-04-28
+ */
+
+package setting
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestValidateGroupsJoinsValidationFailures(t *testing.T) {
+	firstErr := errors.New("first invalid")
+	secondErr := errors.New("second invalid")
+	first := validateTestGroup{err: firstErr}
+	second := validateTestGroup{err: secondErr}
+
+	err := ValidateGroups(first, second)
+	if !errors.Is(err, firstErr) || !errors.Is(err, secondErr) {
+		t.Fatalf("expected joined validation errors, got %v", err)
+	}
+}
+
+func TestValidateGroupsReportsNilGroups(t *testing.T) {
+	if err := ValidateGroups(nil); !errors.Is(err, ErrNilValidatable) {
+		t.Fatalf("expected nil validatable error, got %v", err)
+	}
+
+	var typedNil *validateTestGroup
+	if err := ValidateGroups(typedNil); !errors.Is(err, ErrNilValidatable) {
+		t.Fatalf("expected typed nil validatable error, got %v", err)
+	}
+}
+
+type validateTestGroup struct {
+	err error
+}
+
+func (g validateTestGroup) Validate() error {
+	return g.err
+}


### PR DESCRIPTION
## Description

Add small server setting contracts for defaulting and validation across setting groups.

This PR keeps the concrete server setting aggregate limited to the existing identity and logging groups, while giving future setting groups a reusable way to apply stable defaults and report validation errors before runtime bootstrap consumes them.

## Related Links

- Closes #48
- Refs #24
- Refs #36
- Refs #46

## Scope

- [x] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [ ] Security

## Implementation Notes

- Added `Defaultable` and `DefaultGroups` in `server/internal/setting/default.go`.
- Added `Validatable` and `ValidateGroups` in `server/internal/setting/validate.go`.
- Kept bootstrap-derived identity defaults explicit at the root setting boundary.
- Routed logging defaulting and root validation through the helper functions.
- Did not add concrete HTTP, database, Redis, RabbitMQ, security, or plugin setting schemas.

## Verification

- [x] Tests or checks were run
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

Commands:

```bash
go test -count=1 ./packages/shared/... ./server/...
```

## Risks

- This PR only adds default and validation contracts. Future setting groups still need separate issues for their concrete schema, defaults, and validation rules.
