### PR TITLE
gh-50 [feat]: Add server runtime boot boundary

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -18,14 +18,14 @@
   @File    : server/README.md
   @Author  : Frost Leo <frostleo.dev@gmail.com>
   @Created : 2026-04-24
-  @Modified: 2026-04-28
+  @Modified: 2026-05-31
 -->
 
 # Dox Server
 
 `server` is the Web backend runtime for Dox.
 
-The current module contains the CLI entrypoint, shared version command, bootstrap configuration snapshot loading, and server-owned setting assembly for identity and logging. HTTP server startup, database access, security, and EDA integration are intentionally out of scope for this milestone.
+The current module contains the CLI entrypoint, shared version command, bootstrap configuration snapshot loading, server-owned setting assembly for identity and logging, and the first runtime boot boundary. HTTP server startup, database access, security, and EDA integration are intentionally out of scope for this milestone.
 
 ## Configuration Bootstrap
 
@@ -42,6 +42,22 @@ Raw bootstrap snapshots use `map[string]any` and allow unknown keys so operators
 
 Concrete server setting groups belong under `server/internal/setting`, where each configuration group owns its own file. Current groups cover identity and logging. Concrete HTTP, database, cache, security, and IAM setting structs remain out of scope until those runtime resources are introduced.
 
+## Runtime Boot
+
+The server startup pipeline is:
+
+```text
+dox-server serve
+  -> CLI flags build bootstrap.ConfigOptions
+  -> bootstrap.LoadSetting loads, defaults, and validates settings
+  -> bootstrap.Boot constructs runtime resources from the SettingSnapshot
+  -> Runtime.Shutdown releases resources in reverse construction order
+```
+
+`bootstrap.Boot` does not load configuration sources. It consumes an already validated `SettingSnapshot` and currently constructs the logging runtime resources: logging resource identity, zap core base, Dox logger facade, and OpenTelemetry SDK base without installing global providers.
+
+Future server-owned HTTP, database, queue producer, and plugin host modules should add typed setting groups under `server/internal/setting` and expose constructors that `server/internal/bootstrap` can call. Scheduling, Collection, and Computation runtimes should use their own runtime modules and boot boundaries when they are introduced; they must not attach themselves to the Web backend bootstrap. Feature packages should not import `server/internal/bootstrap`; bootstrap remains the server composition root for this server process only.
+
 ## Usage
 
 From the repository root:
@@ -50,10 +66,17 @@ From the repository root:
 go run ./server version
 ```
 
+Start the server runtime boot path from the repository root. The configured directory must contain `base.<format>`:
+
+```bash
+go run ./server serve --config-dir configs --env dev --config-format yaml
+```
+
 From the `server` module:
 
 ```bash
 go run . version
+go run . serve --config-dir ../configs --env dev --config-format yaml
 ```
 
 Build the server CLI binary from the repository root:

--- a/server/internal/bootstrap/boot.go
+++ b/server/internal/bootstrap/boot.go
@@ -1,0 +1,143 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : boot.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-05-31
+ * @Modified: 2026-05-31
+ */
+
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"syscall"
+
+	sharedconfig "github.com/opendox/dox/packages/shared/config"
+	sharedlogging "github.com/opendox/dox/packages/shared/logging"
+)
+
+// BootOptions carries runtime boot policy toggles.
+type BootOptions struct {
+	// InstallOpenTelemetryGlobals is reserved for a later runtime integration.
+	InstallOpenTelemetryGlobals bool
+}
+
+// Runtime owns resources constructed for the server process.
+type Runtime struct {
+	Snapshot *SettingSnapshot
+	Resource sharedlogging.Resource
+	Logger   sharedlogging.Logger
+
+	zapCore   *sharedlogging.ZapCoreBase
+	otel      *sharedlogging.OpenTelemetrySDKBase
+	lifecycle runtimeLifecycle
+}
+
+// Boot constructs server runtime resources from a validated setting snapshot.
+func Boot(ctx context.Context, snapshot *SettingSnapshot, options BootOptions) (*Runtime, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if snapshot == nil {
+		return nil, sharedconfig.ContractError("snapshot", "setting snapshot must not be nil")
+	}
+	if err := options.validate(); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	resource := loggingResourceFromSnapshot(snapshot)
+	loggingConfig := renderLoggingConfig(snapshot.Setting.Logging, resource)
+	if err := prepareLoggingPaths(loggingConfig); err != nil {
+		return nil, fmt.Errorf("server boot: prepare logging paths: %w", err)
+	}
+
+	runtime := &Runtime{
+		Snapshot: snapshot,
+		Resource: resource,
+	}
+
+	zapCore, err := sharedlogging.NewZapCoreBase(loggingConfig)
+	if err != nil {
+		return nil, fmt.Errorf("server boot: initialize zap core base: %w", err)
+	}
+	runtime.zapCore = zapCore
+	runtime.lifecycle.register("logging.zap_core", func(context.Context) error {
+		zapCore.Close()
+		return nil
+	})
+
+	logger, err := sharedlogging.NewLogger(zapCore, sharedlogging.ResourceAttr(resource))
+	if err != nil {
+		return nil, runtime.rollback(ctx, fmt.Errorf("server boot: initialize logger: %w", err))
+	}
+	runtime.Logger = logger
+	runtime.lifecycle.register("logging.logger", func(context.Context) error {
+		return normalizeLoggerSyncError(logger.Sync())
+	})
+
+	otelBase, err := sharedlogging.NewOpenTelemetrySDKBase(loggingConfig, resource)
+	if err != nil {
+		return nil, runtime.rollback(ctx, fmt.Errorf("server boot: initialize OpenTelemetry SDK base: %w", err))
+	}
+	runtime.otel = otelBase
+	runtime.lifecycle.register("logging.otel", func(ctx context.Context) error {
+		return otelBase.Shutdown(ctx)
+	})
+
+	return runtime, nil
+}
+
+// Shutdown releases runtime resources in reverse construction order.
+func (r *Runtime) Shutdown(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	return r.lifecycle.shutdown(ctx)
+}
+
+func (o BootOptions) validate() error {
+	if o.InstallOpenTelemetryGlobals {
+		return sharedconfig.ContractError(
+			"options.install_open_telemetry_globals",
+			"installing OpenTelemetry globals is not supported by server boot",
+		)
+	}
+	return nil
+}
+
+func (r *Runtime) rollback(ctx context.Context, err error) error {
+	if rollbackErr := r.Shutdown(ctx); rollbackErr != nil {
+		return errors.Join(err, fmt.Errorf("server boot rollback failed: %w", rollbackErr))
+	}
+	return err
+}
+
+func normalizeLoggerSyncError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, syscall.EINVAL) {
+		return nil
+	}
+	return err
+}

--- a/server/internal/bootstrap/boot_test.go
+++ b/server/internal/bootstrap/boot_test.go
@@ -1,0 +1,224 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : boot_test.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-05-31
+ * @Modified: 2026-05-31
+ */
+
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	sharedconfig "github.com/opendox/dox/packages/shared/config"
+	sharedlogging "github.com/opendox/dox/packages/shared/logging"
+	sharedsetting "github.com/opendox/dox/packages/shared/setting"
+	serversetting "github.com/opendox/dox/server/internal/setting"
+)
+
+func TestBootBuildsLoggingRuntimeFromValidatedSetting(t *testing.T) {
+	tempDir := t.TempDir()
+	snapshot := newBootTestSnapshot(t, filepath.Join(tempDir, "${service.namespace}-${service.name}.jsonl"))
+
+	runtime, err := Boot(context.Background(), snapshot, BootOptions{})
+	if err != nil {
+		t.Fatalf("boot runtime: %v", err)
+	}
+
+	if runtime.Snapshot != snapshot {
+		t.Fatal("expected runtime to retain the setting snapshot")
+	}
+	if runtime.Logger == nil {
+		t.Fatal("expected runtime logger to be initialized")
+	}
+	if runtime.Resource.ServiceNamespace != "dox" || runtime.Resource.ServiceName != "api" {
+		t.Fatalf("expected logging resource from identity, got %+v", runtime.Resource)
+	}
+	if runtime.Resource.ServiceVersion != "test-version" {
+		t.Fatalf("expected logging resource version override, got %+v", runtime.Resource)
+	}
+	if runtime.Resource.DeploymentEnvironment != "test" ||
+		runtime.Resource.DoxOrganization != "opendox" ||
+		runtime.Resource.DoxRuntime != "server" {
+		t.Fatalf("expected logging resource deployment identity, got %+v", runtime.Resource)
+	}
+
+	runtime.Logger.Info(context.Background(), "boot logger ready")
+	if err := runtime.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown runtime: %v", err)
+	}
+
+	logPath := filepath.Join(tempDir, "dox-api.jsonl")
+	payload, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read rendered log file %s: %v", logPath, err)
+	}
+	for _, expected := range []string{
+		`"message":"boot logger ready"`,
+		`"service.namespace":"dox"`,
+		`"service.name":"api"`,
+		`"service.version":"test-version"`,
+		`"deployment.environment.name":"test"`,
+		`"dox.runtime":"server"`,
+	} {
+		if !strings.Contains(string(payload), expected) {
+			t.Fatalf("expected log payload to contain %s, got:\n%s", expected, payload)
+		}
+	}
+}
+
+func TestBootRejectsNilSnapshot(t *testing.T) {
+	_, err := Boot(context.Background(), nil, BootOptions{})
+
+	if !sharedconfig.IsKind(err, sharedconfig.ErrorKindContract) {
+		t.Fatalf("expected contract error for nil snapshot, got %v", err)
+	}
+}
+
+func TestBootRejectsUnsupportedOpenTelemetryGlobalInstallOption(t *testing.T) {
+	snapshot := newBootTestSnapshot(t, filepath.Join(t.TempDir(), "service.jsonl"))
+
+	_, err := Boot(context.Background(), snapshot, BootOptions{
+		InstallOpenTelemetryGlobals: true,
+	})
+
+	if !sharedconfig.IsKind(err, sharedconfig.ErrorKindContract) {
+		t.Fatalf("expected contract error for unsupported boot option, got %v", err)
+	}
+}
+
+func TestBootReturnsOpenTelemetrySetupError(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "service.jsonl")
+	snapshot := newBootTestSnapshot(t, logPath)
+	snapshot.Setting.Logging.OTel.Enabled = boolPtr(true)
+	snapshot.Setting.Logging.OTel.Exporter.OTLP.Enabled = true
+	snapshot.Setting.Logging.OTel.Exporter.OTLP.Endpoint = "http://127.0.0.1:4318"
+
+	_, err := Boot(context.Background(), snapshot, BootOptions{})
+
+	if err == nil {
+		t.Fatal("expected boot to fail when unsupported OTLP exporter setup is requested")
+	}
+	if !strings.Contains(err.Error(), "OpenTelemetry") {
+		t.Fatalf("expected OpenTelemetry setup error, got %v", err)
+	}
+
+	if removeErr := os.Remove(logPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		t.Fatalf("expected boot rollback to release logging file sink, got remove error: %v", removeErr)
+	}
+}
+
+func TestRuntimeLifecycleShutdownRunsHooksInReverseOrderAndAggregatesErrors(t *testing.T) {
+	firstErr := errors.New("first cleanup failed")
+	secondErr := errors.New("second cleanup failed")
+	var order []string
+
+	lifecycle := runtimeLifecycle{}
+	lifecycle.register("first", func(context.Context) error {
+		order = append(order, "first")
+		return firstErr
+	})
+	lifecycle.register("second", func(context.Context) error {
+		order = append(order, "second")
+		return secondErr
+	})
+
+	err := lifecycle.shutdown(context.Background())
+
+	if !reflect.DeepEqual(order, []string{"second", "first"}) {
+		t.Fatalf("expected reverse shutdown order, got %#v", order)
+	}
+	if !errors.Is(err, firstErr) || !errors.Is(err, secondErr) {
+		t.Fatalf("expected shutdown error to preserve cleanup failures, got %v", err)
+	}
+
+	order = nil
+	if err := lifecycle.shutdown(context.Background()); err != nil {
+		t.Fatalf("expected second shutdown to be idempotent, got %v", err)
+	}
+	if len(order) != 0 {
+		t.Fatalf("expected second shutdown to skip already-run hooks, got %#v", order)
+	}
+}
+
+func newBootTestSnapshot(t *testing.T, outputPath string) *SettingSnapshot {
+	t.Helper()
+
+	setting := serversetting.Setting{
+		Identity: serversetting.Identity{
+			Service: sharedsetting.Service{
+				Name:       "api",
+				InstanceID: "server-01",
+			},
+			Deployment: sharedsetting.Deployment{
+				Region:       "us-east-1",
+				Zone:         "use1-az1",
+				Cluster:      "dox-test",
+				K8sNamespace: "dox-system",
+			},
+		},
+		Logging: sharedlogging.Config{
+			Resource: sharedlogging.ResourceConfig{
+				ServiceVersion: "test-version",
+			},
+			Zap: sharedlogging.ZapConfig{
+				DisableCaller:       true,
+				DisableStacktrace:   true,
+				DisableErrorVerbose: true,
+				ErrorOutputPaths:    []string{filepath.Join(filepath.Dir(outputPath), "errors.log")},
+			},
+			Cores: []sharedlogging.CoreConfig{
+				{
+					Name:        "service-file",
+					Enabled:     boolPtr(true),
+					Type:        sharedlogging.CoreTypeFile,
+					Level:       sharedlogging.LevelInfo,
+					Encoding:    sharedlogging.EncodingJSON,
+					OutputPaths: []string{outputPath},
+					Datasets:    []string{"*"},
+					Rotation: sharedlogging.RotationConfig{
+						Driver: sharedlogging.RotationDriverNone,
+					},
+				},
+			},
+		},
+	}
+	if err := setting.DefaultWithOptions(serversetting.DefaultOptions{Env: "test"}); err != nil {
+		t.Fatalf("default test setting: %v", err)
+	}
+	if err := setting.Validate(); err != nil {
+		t.Fatalf("validate test setting: %v", err)
+	}
+
+	return &SettingSnapshot{
+		Runtime: configRuntime,
+		Env:     "test",
+		Setting: setting,
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}

--- a/server/internal/bootstrap/lifecycle.go
+++ b/server/internal/bootstrap/lifecycle.go
@@ -1,0 +1,73 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : lifecycle.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-05-31
+ * @Modified: 2026-05-31
+ */
+
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ShutdownFunc releases one runtime resource.
+type ShutdownFunc func(context.Context) error
+
+type shutdownHook struct {
+	name string
+	fn   ShutdownFunc
+}
+
+type runtimeLifecycle struct {
+	hooks []shutdownHook
+}
+
+func (l *runtimeLifecycle) register(name string, fn ShutdownFunc) {
+	if l == nil || fn == nil {
+		return
+	}
+	l.hooks = append(l.hooks, shutdownHook{
+		name: name,
+		fn:   fn,
+	})
+}
+
+func (l *runtimeLifecycle) shutdown(ctx context.Context) error {
+	if l == nil || len(l.hooks) == 0 {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	hooks := l.hooks
+	l.hooks = nil
+
+	var err error
+	for index := len(hooks) - 1; index >= 0; index-- {
+		hook := hooks[index]
+		if shutdownErr := hook.fn(ctx); shutdownErr != nil {
+			err = errors.Join(err, fmt.Errorf("%s: %w", hook.name, shutdownErr))
+		}
+	}
+	return err
+}

--- a/server/internal/bootstrap/logging.go
+++ b/server/internal/bootstrap/logging.go
@@ -1,0 +1,149 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : logging.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-05-31
+ * @Modified: 2026-05-31
+ */
+
+package bootstrap
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	sharedlogging "github.com/opendox/dox/packages/shared/logging"
+	"github.com/opendox/dox/packages/shared/version"
+)
+
+func loggingResourceFromSnapshot(snapshot *SettingSnapshot) sharedlogging.Resource {
+	identity := snapshot.Setting.Identity
+	serviceVersion := version.GetInfo().Version
+	if override := strings.TrimSpace(snapshot.Setting.Logging.Resource.ServiceVersion); override != "" {
+		serviceVersion = override
+	}
+
+	return sharedlogging.Resource{
+		ServiceNamespace:      identity.Service.Namespace,
+		ServiceName:           identity.Service.Name,
+		ServiceInstanceID:     identity.Service.InstanceID,
+		ServiceVersion:        serviceVersion,
+		DeploymentEnvironment: string(identity.Deployment.Env),
+		CloudRegion:           identity.Deployment.Region,
+		CloudAvailabilityZone: identity.Deployment.Zone,
+		K8sClusterName:        identity.Deployment.Cluster,
+		K8sNamespaceName:      identity.Deployment.K8sNamespace,
+		DoxOrganization:       identity.Organization.Name,
+		DoxApplication:        identity.Application.Name,
+		DoxRuntime:            string(identity.System.Runtime),
+	}
+}
+
+func renderLoggingConfig(config sharedlogging.Config, resource sharedlogging.Resource) sharedlogging.Config {
+	render := loggingPathRenderer(resource)
+
+	config.Zap.OutputPaths = renderPaths(config.Zap.OutputPaths, render)
+	config.Zap.ErrorOutputPaths = renderPaths(config.Zap.ErrorOutputPaths, render)
+	if len(config.Cores) > 0 {
+		cores := make([]sharedlogging.CoreConfig, len(config.Cores))
+		copy(cores, config.Cores)
+		for index := range cores {
+			cores[index].OutputPaths = renderPaths(cores[index].OutputPaths, render)
+		}
+		config.Cores = cores
+	}
+	return config
+}
+
+func loggingPathRenderer(resource sharedlogging.Resource) *strings.Replacer {
+	return strings.NewReplacer(
+		"${service.namespace}", resource.ServiceNamespace,
+		"${service.name}", resource.ServiceName,
+		"${service.instance.id}", resource.ServiceInstanceID,
+		"${service.version}", resource.ServiceVersion,
+		"${deployment.environment.name}", resource.DeploymentEnvironment,
+		"${cloud.region}", resource.CloudRegion,
+		"${cloud.availability_zone}", resource.CloudAvailabilityZone,
+		"${k8s.cluster.name}", resource.K8sClusterName,
+		"${k8s.namespace.name}", resource.K8sNamespaceName,
+		"${dox.organization}", resource.DoxOrganization,
+		"${dox.application}", resource.DoxApplication,
+		"${dox.runtime}", resource.DoxRuntime,
+	)
+}
+
+func renderPaths(paths []string, render *strings.Replacer) []string {
+	if paths == nil {
+		return nil
+	}
+	rendered := make([]string, len(paths))
+	for index, path := range paths {
+		rendered[index] = render.Replace(path)
+	}
+	return rendered
+}
+
+func prepareLoggingPaths(config sharedlogging.Config) error {
+	for _, path := range config.Zap.OutputPaths {
+		if err := prepareLogFilePath(path); err != nil {
+			return fmt.Errorf("prepare zap output path %q: %w", path, err)
+		}
+	}
+	for _, path := range config.Zap.ErrorOutputPaths {
+		if err := prepareLogFilePath(path); err != nil {
+			return fmt.Errorf("prepare zap error output path %q: %w", path, err)
+		}
+	}
+	for _, core := range config.Cores {
+		if core.Type != sharedlogging.CoreTypeFile {
+			continue
+		}
+		for _, path := range core.OutputPaths {
+			if err := prepareLogFilePath(path); err != nil {
+				return fmt.Errorf("prepare logging core %q output path %q: %w", core.Name, path, err)
+			}
+		}
+	}
+	return nil
+}
+
+func prepareLogFilePath(path string) error {
+	path = strings.TrimSpace(path)
+	if !isLocalLogFilePath(path) {
+		return nil
+	}
+
+	dir := filepath.Dir(path)
+	if dir == "." || dir == "" {
+		return nil
+	}
+	return os.MkdirAll(dir, 0o755)
+}
+
+func isLocalLogFilePath(path string) bool {
+	if path == "" {
+		return false
+	}
+	switch path {
+	case "stdout", "stderr":
+		return false
+	}
+	return !strings.Contains(path, "://")
+}

--- a/server/internal/command/root.go
+++ b/server/internal/command/root.go
@@ -18,7 +18,7 @@
  * @File    : root.go
  * @Author  : Frost Leo <frostleo.dev@gmail.com>
  * @Created : 2026-04-24
- * @Modified: 2026-04-24
+ * @Modified: 2026-05-31
  */
 
 package command
@@ -33,8 +33,9 @@ import (
 
 // Config defines external command streams for the server CLI.
 type Config struct {
-	Out    io.Writer
-	ErrOut io.Writer
+	Out       io.Writer
+	ErrOut    io.Writer
+	ServeWait ServeWaitFunc
 }
 
 // Execute runs the server CLI with explicit args and stream configuration.
@@ -64,6 +65,7 @@ func NewRootCommand(cfg Config) *cobra.Command {
 	}
 	cmd.SetOut(out)
 	cmd.SetErr(errOut)
+	cmd.AddCommand(newServeCommand(cfg))
 	cmd.AddCommand(newVersionCommand())
 	return cmd
 }

--- a/server/internal/command/root_test.go
+++ b/server/internal/command/root_test.go
@@ -18,7 +18,7 @@
  * @File    : root_test.go
  * @Author  : Frost Leo <frostleo.dev@gmail.com>
  * @Created : 2026-04-24
- * @Modified: 2026-04-24
+ * @Modified: 2026-05-31
  */
 
 package command
@@ -26,8 +26,12 @@ package command
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/opendox/dox/server/internal/bootstrap"
 )
 
 func TestRootCommandMetadata(t *testing.T) {
@@ -38,6 +42,18 @@ func TestRootCommandMetadata(t *testing.T) {
 	}
 	if cmd.Short == "" {
 		t.Fatal("expected root command short description")
+	}
+}
+
+func TestRootCommandRegistersServeCommand(t *testing.T) {
+	cmd := NewRootCommand(Config{})
+
+	serve, _, err := cmd.Find([]string{"serve"})
+	if err != nil {
+		t.Fatalf("find serve command: %v", err)
+	}
+	if serve == nil || serve.Use != "serve" {
+		t.Fatalf("expected serve command to be registered, got %#v", serve)
 	}
 }
 
@@ -58,5 +74,109 @@ func TestVersionCommandPrintsSharedVersionInfo(t *testing.T) {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("expected version output to contain %q, got:\n%s", expected, output)
 		}
+	}
+}
+
+func TestServeCommandLoadsSettingBootsAndStops(t *testing.T) {
+	dir := t.TempDir()
+	logDir := t.TempDir()
+	writeCommandFixture(t, filepath.Join(dir, "base.yaml"), `
+identity:
+  service:
+    name: api
+logging:
+  resource:
+    service_version: command-test
+  zap:
+    disable_caller: true
+    disable_stacktrace: true
+    disable_error_verbose: true
+    error_output_paths:
+      - "`+filepath.Join(logDir, "errors.log")+`"
+  cores:
+    - name: service-file
+      enabled: true
+      type: file
+      level: info
+      encoding: json
+      output_paths:
+        - "`+filepath.Join(logDir, "${service.namespace}-${service.name}.jsonl")+`"
+      datasets: ["*"]
+      rotation:
+        driver: none
+`)
+
+	var booted bool
+	err := Execute(context.Background(), []string{
+		"serve",
+		"--config-dir", dir,
+		"--env", "test",
+		"--config-format", "yaml",
+		"--env-prefix", "DOX_COMMAND_TEST_SERVE_SUCCESS_",
+		"--config-timeout", "2s",
+	}, Config{
+		ServeWait: func(ctx context.Context, runtime *bootstrap.Runtime) error {
+			booted = true
+			if runtime == nil || runtime.Logger == nil {
+				t.Fatalf("expected booted runtime with logger, got %#v", runtime)
+			}
+			if runtime.Resource.ServiceName != "api" || runtime.Resource.ServiceVersion != "command-test" {
+				t.Fatalf("expected serve command to boot loaded setting, got %+v", runtime.Resource)
+			}
+			runtime.Logger.Info(ctx, "serve command ready")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected serve command to succeed: %v", err)
+	}
+	if !booted {
+		t.Fatal("expected serve wait hook to observe a booted runtime")
+	}
+
+	payload, err := os.ReadFile(filepath.Join(logDir, "dox-api.jsonl"))
+	if err != nil {
+		t.Fatalf("expected serve shutdown to flush runtime logs: %v", err)
+	}
+	if !strings.Contains(string(payload), `"message":"serve command ready"`) {
+		t.Fatalf("expected serve runtime log to be flushed, got:\n%s", payload)
+	}
+}
+
+func TestServeCommandReturnsConfigLoadError(t *testing.T) {
+	err := Execute(context.Background(), []string{
+		"serve",
+		"--config-dir", t.TempDir(),
+		"--env", "test",
+		"--config-format", "yaml",
+		"--env-prefix", "DOX_COMMAND_TEST_SERVE_MISSING_",
+	}, Config{
+		ServeWait: func(context.Context, *bootstrap.Runtime) error {
+			t.Fatal("serve wait must not run when setting loading fails")
+			return nil
+		},
+	})
+
+	if err == nil {
+		t.Fatal("expected serve command to return config load error")
+	}
+}
+
+func TestWaitForContextCancellationReturnsAfterCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := waitForContextCancellation(ctx, nil); err != nil {
+		t.Fatalf("expected canceled context to stop wait without an error, got %v", err)
+	}
+}
+
+func writeCommandFixture(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create fixture dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(content, "\n")), 0o644); err != nil {
+		t.Fatalf("write fixture %s: %v", path, err)
 	}
 }

--- a/server/internal/command/serve.go
+++ b/server/internal/command/serve.go
@@ -1,0 +1,83 @@
+/**
+ * dox
+ * Copyright (C) 2026  OpenDox
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @File    : serve.go
+ * @Author  : Frost Leo <frostleo.dev@gmail.com>
+ * @Created : 2026-05-31
+ * @Modified: 2026-05-31
+ */
+
+package command
+
+import (
+	"context"
+	"errors"
+
+	"github.com/opendox/dox/server/internal/bootstrap"
+	"github.com/spf13/cobra"
+)
+
+// ServeWaitFunc waits until the booted server runtime should shut down.
+type ServeWaitFunc func(context.Context, *bootstrap.Runtime) error
+
+func newServeCommand(cfg Config) *cobra.Command {
+	options := bootstrap.ConfigOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start the Dox Web backend runtime",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			snapshot, err := bootstrap.LoadSetting(ctx, options)
+			if err != nil {
+				return err
+			}
+
+			runtime, err := bootstrap.Boot(ctx, snapshot, bootstrap.BootOptions{})
+			if err != nil {
+				return err
+			}
+
+			wait := cfg.ServeWait
+			if wait == nil {
+				wait = waitForContextCancellation
+			}
+
+			waitErr := wait(ctx, runtime)
+			shutdownErr := runtime.Shutdown(context.Background())
+			return errors.Join(waitErr, shutdownErr)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&options.ConfigDir, "config-dir", bootstrap.DefaultConfigDir, "Directory containing server configuration files")
+	flags.StringVar(&options.Env, "env", bootstrap.DefaultConfigEnv, "Server runtime environment")
+	flags.StringVar(&options.Format, "config-format", bootstrap.DefaultConfigFormat, "Server configuration file format")
+	flags.StringVar(&options.EnvPrefix, "env-prefix", bootstrap.DefaultConfigEnvPrefix, "Environment variable prefix for server configuration overrides")
+	flags.DurationVar(&options.Timeout, "config-timeout", 0, "Optional timeout for server configuration loading")
+
+	return cmd
+}
+
+func waitForContextCancellation(ctx context.Context, runtime *bootstrap.Runtime) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	<-ctx.Done()
+	return nil
+}

--- a/server/internal/setting/README.md
+++ b/server/internal/setting/README.md
@@ -18,18 +18,18 @@
   @File    : server/internal/setting/README.md
   @Author  : Frost Leo <frostleo.dev@gmail.com>
   @Created : 2026-04-26
-  @Modified: 2026-04-28
+  @Modified: 2026-05-31
 -->
 
 # Server Setting
 
 `server/internal/setting` owns the concrete configuration aggregate for the Dox Web backend runtime.
 
-Shared packages provide reusable configuration fragments. This package decides how the server runtime composes those fragments, which defaults are server-specific, and which validation rules are stricter than the shared fragment rules.
+Shared packages provide reusable configuration fragments. This package decides how the Web backend server runtime composes those fragments, which defaults are server-specific, and which validation rules are stricter than the shared fragment rules. Scheduler, collector, and computation runtimes should own separate setting aggregates when they are introduced.
 
 ## Boundaries
 
-- `server/internal/bootstrap` loads source snapshots from files and environment variables, then assembles typed server settings.
+- `server/internal/bootstrap` loads source snapshots from files and environment variables, assembles typed server settings, and boots runtime resources from validated snapshots.
 - `packages/shared/config` provides source loading, merging, and decoding primitives.
 - `packages/shared/setting` defines reusable setting fragments.
 - `packages/shared/logging` defines the shared logging model and runtime helper configuration.
@@ -43,7 +43,7 @@ The expected assembly order is:
 2. `packages/shared/config` loads and merges raw values into a `map[string]any` snapshot.
 3. `server/internal/bootstrap` decodes the snapshot into `Setting` with unknown keys rejected.
 4. `server/internal/setting` applies defaults and validates group semantics.
-5. Later runtime bootstrap code receives validated narrow setting groups and constructs resources.
+5. `server/internal/bootstrap.Boot` receives the validated `SettingSnapshot` and constructs runtime resources.
 
 ## File Convention
 
@@ -90,7 +90,7 @@ type Validatable interface {
 
 `ValidateGroups` validates groups and joins reported errors so startup can report every invalid group found in one pass.
 
-Future HTTP, database, Redis, RabbitMQ, security, plugin, and similar setting groups should plug into these default and validation contracts before runtime bootstrap consumes them. The contracts do not define those concrete groups, construct clients, open network listeners, resolve secrets, or start runtime resources.
+Future server-owned HTTP, database, Redis, RabbitMQ producer, security, plugin host, and similar setting groups should plug into these default and validation contracts before server runtime bootstrap consumes them. Scheduler, collector, and computation runtime settings should not be added to this package only because they share deployment infrastructure. The contracts do not define those concrete groups, construct clients, open network listeners, resolve secrets, or start runtime resources.
 
 ## Identity
 
@@ -110,6 +110,6 @@ The server package defaults `System.Runtime` to `server`. That default does not 
 
 The logging group is backed by `packages/shared/logging.Config`.
 
-Server settings own loading, defaulting, and validation of this group. Runtime bootstrap will later decide how to construct zap cores, the Dox logger facade, and OpenTelemetry providers from the validated config.
+Server settings own loading, defaulting, and validation of this group. Runtime bootstrap constructs zap cores, the Dox logger facade, and the OpenTelemetry SDK base from the validated config.
 
 This package must not open logging sinks, create log files, install OpenTelemetry globals, or wire HTTP/server modules to logging.

--- a/server/main.go
+++ b/server/main.go
@@ -18,7 +18,7 @@
  * @File    : main.go
  * @Author  : Frost Leo <frostleo.dev@gmail.com>
  * @Created : 2026-04-24
- * @Modified: 2026-04-24
+ * @Modified: 2026-05-31
  */
 
 package main
@@ -27,12 +27,17 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/opendox/dox/server/internal/command"
 )
 
 func main() {
-	if err := command.Execute(context.Background(), os.Args[1:], command.Config{}); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := command.Execute(ctx, os.Args[1:], command.Config{}); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Description

Adds the first Web backend server runtime boot boundary for issue #50. The startup flow now loads validated server settings, boots logging runtime resources, and releases resources through an explicit runtime lifecycle.

## Related Links

- Closes #50
- Refs #46
- Refs #48

## Scope

- [x] Web
- [ ] Scheduling
- [ ] Collection
- [ ] Computation
- [ ] Plugin
- [ ] Frontend
- [ ] Database
- [x] Documentation
- [ ] CI / tooling
- [ ] Security

## Implementation Notes

- `bootstrap.Boot` consumes a validated `SettingSnapshot`; configuration loading remains before boot through `bootstrap.LoadSetting`.
- The runtime currently constructs logging identity, zap core base, Dox logger facade, and OpenTelemetry SDK base without installing global providers.
- `dox-server serve` wires CLI flags into `LoadSetting -> Boot -> wait -> Runtime.Shutdown`.
- Scheduling, Collection, and Computation are intentionally left outside this server bootstrap boundary so future runtimes can own their own settings and boot flows.

## Verification

- [x] Tests or checks were run: `go test -count=1 ./packages/shared/... ./server/...`
- [x] `git diff --check HEAD~1..HEAD`
- [x] Documentation was updated or is not required
- [x] Database/configuration impact was reviewed
- [x] Security and secret exposure risk was reviewed

## Risks

- `serve` boots runtime logging only; HTTP listener, database clients, queue producers, and plugin host wiring remain follow-up work.
- Logging redaction, buffering, and dataset routing remain contract-level behavior in the shared logging package.
- OpenTelemetry global provider installation and OTLP exporter setup remain unsupported until a later runtime integration.
